### PR TITLE
Lock Kustomize dependencies to version not affected by KYAML issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,6 @@ require (
 	k8s.io/api v0.20.2
 	k8s.io/apimachinery v0.20.2
 	k8s.io/client-go v0.20.2
-	sigs.k8s.io/kustomize/api v0.7.3
-	sigs.k8s.io/kustomize/kyaml v0.10.8
+	sigs.k8s.io/kustomize/api v0.6.9
+	sigs.k8s.io/kustomize/kyaml v0.10.7
 )

--- a/go.sum
+++ b/go.sum
@@ -1086,12 +1086,10 @@ mvdan.cc/unparam v0.0.0-20190720180237-d51796306d8f/go.mod h1:4G1h5nDURzA3bwVMZI
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sigs.k8s.io/kustomize/api v0.7.3 h1:5ZlS24VT7Tm1BXNeqkdC/UsX+ahdMVVojt5aP+5S3ME=
-sigs.k8s.io/kustomize/api v0.7.3/go.mod h1:4RLLidX0T3BWrC6gsRqz6uCJ6OXFecXfh/3QDHMauOg=
+sigs.k8s.io/kustomize/api v0.6.9 h1:wJK+JujSyRemVxESNvk0bXjBMcDkJk0IbDkQ+8yRKO4=
+sigs.k8s.io/kustomize/api v0.6.9/go.mod h1:4RLLidX0T3BWrC6gsRqz6uCJ6OXFecXfh/3QDHMauOg=
 sigs.k8s.io/kustomize/kyaml v0.10.7 h1:r0r8UEL0bL7X56HKUmhJZ+TP+nvRNGrDHHSLO7izlcQ=
 sigs.k8s.io/kustomize/kyaml v0.10.7/go.mod h1:K9yg1k/HB/6xNOf5VH3LhTo1DK9/5ykSZO5uIv+Y/1k=
-sigs.k8s.io/kustomize/kyaml v0.10.8 h1:z5BAm9ZCfaXGnZOLIF7p9cYZMUoftUmYhDziESumVoI=
-sigs.k8s.io/kustomize/kyaml v0.10.8/go.mod h1:K9yg1k/HB/6xNOf5VH3LhTo1DK9/5ykSZO5uIv+Y/1k=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e h1:4Z09Hglb792X0kfOBBJUPFEyvVfQWrYT/l8h5EKA6JQ=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2 h1:YHQV7Dajm86OuqnIR6zAelnDWBRjo+YhYV9PmGrh1s8=

--- a/kustomize/data_source_kustomization_overlay_test.go
+++ b/kustomize/data_source_kustomization_overlay_test.go
@@ -104,7 +104,7 @@ func TestDataSourceKustomizationOverlay_commonAnnotations(t *testing.T) {
 			{
 				Config: testDataSourceKustomizationOverlayConfig_commonAnnotations(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckOutput("check", "{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{\"test-annotation\":\"true\"},\"name\":\"test-basic\"}}"),
+					resource.TestCheckOutput("check", "{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"annotations\":{\"test-annotation\":\"true\"},\"name\":\"test-basic\"}}\n"),
 				),
 			},
 		},
@@ -141,7 +141,7 @@ func TestDataSourceKustomizationOverlay_commonLabels(t *testing.T) {
 			{
 				Config: testDataSourceKustomizationOverlayConfig_commonLabels(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckOutput("check", "{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"labels\":{\"test-label\":\"true\"},\"name\":\"test-basic\"}}"),
+					resource.TestCheckOutput("check", "{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"labels\":{\"test-label\":\"true\"},\"name\":\"test-basic\"}}\n"),
 				),
 			},
 		},
@@ -178,7 +178,7 @@ func TestDataSourceKustomizationOverlay_components(t *testing.T) {
 			{
 				Config: testDataSourceKustomizationOverlayConfig_components(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckOutput("check", "{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\",\"metadata\":{\"name\":\"from-component-6ct58987ht\"}}"),
+					resource.TestCheckOutput("check", "{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\",\"metadata\":{\"name\":\"from-component-6ct58987ht\"}}\n"),
 				),
 			},
 		},
@@ -211,8 +211,8 @@ func TestDataSourceKustomizationOverlay_configMapGenerator(t *testing.T) {
 			{
 				Config: testKustomizationConfigMapGeneratorConfig(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckOutput("check_cm1", "{\"apiVersion\":\"v1\",\"data\":{\"KEY1\":\"VALUE1\",\"KEY2\":\"VALUE2\"},\"kind\":\"ConfigMap\",\"metadata\":{\"name\":\"test-configmap1\"}}"),
-					resource.TestCheckOutput("check_cm2", "{\"apiVersion\":\"v1\",\"data\":{\"ENV1\":\"VALUE1\",\"ENV2\":\"VALUE2\",\"KEY1\":\"VALUE1\",\"KEY2\":\"VALUE2\",\"properties.env\":\"ENV1=VALUE1\\nENV2=VALUE2\\n\"},\"kind\":\"ConfigMap\",\"metadata\":{\"name\":\"test-configmap2-5tgmgc9cmf\"}}"),
+					resource.TestCheckOutput("check_cm1", "{\"apiVersion\":\"v1\",\"data\":{\"KEY1\":\"VALUE1\",\"KEY2\":\"VALUE2\"},\"kind\":\"ConfigMap\",\"metadata\":{\"name\":\"test-configmap1\"}}\n"),
+					resource.TestCheckOutput("check_cm2", "{\"apiVersion\":\"v1\",\"data\":{\"ENV1\":\"VALUE1\",\"ENV2\":\"VALUE2\",\"KEY1\":\"VALUE1\",\"KEY2\":\"VALUE2\",\"properties.env\":\"ENV1=VALUE1\\nENV2=VALUE2\\n\"},\"kind\":\"ConfigMap\",\"metadata\":{\"name\":\"test-configmap2-5tgmgc9cmf\"}}\n"),
 				),
 			},
 		},
@@ -272,7 +272,7 @@ func TestDataSourceKustomizationOverlay_namespace(t *testing.T) {
 			{
 				Config: testDataSourceKustomizationOverlayConfig_namespace(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckOutput("check", "{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"name\":\"test-overlay-namespace\"}}"),
+					resource.TestCheckOutput("check", "{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"name\":\"test-overlay-namespace\"}}\n"),
 				),
 			},
 		},
@@ -308,7 +308,7 @@ func TestDataSourceKustomizationOverlay_name_prefix_suffix(t *testing.T) {
 			{
 				Config: testDataSourceKustomizationOverlayConfig_name_prefix_suffix(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckOutput("check", "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"test\"},\"name\":\"test-test-test\",\"namespace\":\"test-basic\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":80}],\"selector\":{\"app\":\"test\"},\"type\":\"ClusterIP\"},\"status\":{\"loadBalancer\":{}}}"),
+					resource.TestCheckOutput("check", "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"test\"},\"name\":\"test-test-test\",\"namespace\":\"test-basic\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":80}],\"selector\":{\"app\":\"test\"},\"type\":\"ClusterIP\"},\"status\":{\"loadBalancer\":{}}}\n"),
 				),
 			},
 		},
@@ -345,7 +345,7 @@ func TestDataSourceKustomizationOverlay_resources(t *testing.T) {
 			{
 				Config: testDataSourceKustomizationOverlayConfig_resources(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckOutput("check", "{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"name\":\"test-basic\"}}"),
+					resource.TestCheckOutput("check", "{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"name\":\"test-basic\"}}\n"),
 				),
 			},
 		},
@@ -378,7 +378,7 @@ func TestDataSourceKustomizationOverlay_transformers(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testDataSourceKustomizationOverlayConfig_transformers(),
-				Check:  resource.TestCheckOutput("check", "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"test\",\"test.example.com/test-label\":\"test-value\"},\"name\":\"test\",\"namespace\":\"test-transformer-config\"},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"test\"}},\"strategy\":{},\"template\":{\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"test\"}},\"spec\":{\"containers\":[{\"image\":\"nginx\",\"name\":\"nginx\",\"resources\":{}}]}}},\"status\":{}}"),
+				Check:  resource.TestCheckOutput("check", "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"test\",\"test.example.com/test-label\":\"test-value\"},\"name\":\"test\",\"namespace\":\"test-transformer-config\"},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"test\"}},\"strategy\":{},\"template\":{\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"test\"}},\"spec\":{\"containers\":[{\"image\":\"nginx\",\"name\":\"nginx\",\"resources\":{}}]}}},\"status\":{}}\n"),
 			},
 		},
 	})
@@ -443,7 +443,7 @@ func TestDataSourceKustomizationOverlay_generators(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testDataSourceKustomizationOverlayConfig_generators(),
-				Check:  resource.TestCheckOutput("check", "{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\",\"metadata\":{\"name\":\"testcm-6ct58987ht\"}}"),
+				Check:  resource.TestCheckOutput("check", "{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\",\"metadata\":{\"name\":\"testcm-6ct58987ht\"}}\n"),
 			},
 		},
 	})
@@ -475,8 +475,8 @@ func TestDataSourceKustomizationOverlay_generator_options(t *testing.T) {
 			{
 				Config: testKustomizationConfig_generator_options(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckOutput("check_configmap", "{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\",\"metadata\":{\"annotations\":{\"test-annotation\":\"test\"},\"labels\":{\"test-label\":\"test\"},\"name\":\"test-configmap\"}}"),
-					resource.TestCheckOutput("check_secret", "{\"apiVersion\":\"v1\",\"data\":{},\"kind\":\"Secret\",\"metadata\":{\"annotations\":{\"test-annotation\":\"test\"},\"labels\":{\"test-label\":\"test\"},\"name\":\"test-secret\"},\"type\":\"Opaque\"}"),
+					resource.TestCheckOutput("check_configmap", "{\"apiVersion\":\"v1\",\"kind\":\"ConfigMap\",\"metadata\":{\"annotations\":{\"test-annotation\":\"test\"},\"labels\":{\"test-label\":\"test\"},\"name\":\"test-configmap\"}}\n"),
+					resource.TestCheckOutput("check_secret", "{\"apiVersion\":\"v1\",\"kind\":\"Secret\",\"metadata\":{\"annotations\":{\"test-annotation\":\"test\"},\"labels\":{\"test-label\":\"test\"},\"name\":\"test-secret\"},\"type\":\"Opaque\"}\n"),
 				),
 			},
 		},
@@ -530,7 +530,7 @@ func TestDataSourceKustomizationOverlay_images(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testKustomizationImagesConfig(),
-				Check:  resource.TestCheckOutput("check", "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"test\"},\"name\":\"test\",\"namespace\":\"test-basic\"},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"test\"}},\"strategy\":{},\"template\":{\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"test\"}},\"spec\":{\"containers\":[{\"image\":\"testname@sha256:abcdefghijklmnop123456\",\"name\":\"nginx\",\"resources\":{}}]}}},\"status\":{}}"),
+				Check:  resource.TestCheckOutput("check", "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"test\"},\"name\":\"test\",\"namespace\":\"test-basic\"},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"test\"}},\"strategy\":{},\"template\":{\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"test\"}},\"spec\":{\"containers\":[{\"image\":\"testname@sha256:abcdefghijklmnop123456\",\"name\":\"nginx\",\"resources\":{}}]}}},\"status\":{}}\n"),
 			},
 		},
 	})
@@ -569,8 +569,8 @@ func TestDataSourceKustomizationOverlay_patches(t *testing.T) {
 			{
 				Config: testKustomizationPatchesConfig(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckOutput("check_dep", "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"labels\":{\"app\":\"test\"},\"name\":\"test\",\"namespace\":\"test-basic\"},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"test\"}},\"strategy\":{},\"template\":{\"metadata\":{\"labels\":{\"app\":\"test\"}},\"spec\":{\"containers\":[{\"env\":[{\"name\":\"TESTENV\",\"value\":\"true\"}],\"image\":\"nginx\",\"name\":\"nginx\",\"resources\":{}}]}}},\"status\":{}}"),
-					resource.TestCheckOutput("check_ingress", "{\"apiVersion\":\"networking.k8s.io/v1beta1\",\"kind\":\"Ingress\",\"metadata\":{\"annotations\":{\"nginx.ingress.kubernetes.io/rewrite-target\":\"/\"},\"name\":\"test\",\"namespace\":\"test-basic\"},\"spec\":{\"rules\":[{\"http\":{\"paths\":[{\"backend\":{\"serviceName\":\"test\",\"servicePort\":80},\"path\":\"/newpath\"}]}}]}}"),
+					resource.TestCheckOutput("check_dep", "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"labels\":{\"app\":\"test\"},\"name\":\"test\",\"namespace\":\"test-basic\"},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"test\"}},\"strategy\":{},\"template\":{\"metadata\":{\"labels\":{\"app\":\"test\"}},\"spec\":{\"containers\":[{\"env\":[{\"name\":\"TESTENV\",\"value\":\"true\"}],\"image\":\"nginx\",\"name\":\"nginx\",\"resources\":{}}]}}},\"status\":{}}\n"),
+					resource.TestCheckOutput("check_ingress", "{\"apiVersion\":\"networking.k8s.io/v1beta1\",\"kind\":\"Ingress\",\"metadata\":{\"annotations\":{\"nginx.ingress.kubernetes.io/rewrite-target\":\"/\"},\"name\":\"test\",\"namespace\":\"test-basic\"},\"spec\":{\"rules\":[{\"http\":{\"paths\":[{\"backend\":{\"serviceName\":\"test\",\"servicePort\":80},\"path\":\"/newpath\"}]}}]}}\n"),
 				),
 			},
 		},
@@ -629,7 +629,7 @@ func TestDataSourceKustomizationOverlay_replicas(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testKustomizationReplicasConfig(),
-				Check:  resource.TestCheckOutput("check", "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"test\"},\"name\":\"test\",\"namespace\":\"test-basic\"},\"spec\":{\"replicas\":5,\"selector\":{\"matchLabels\":{\"app\":\"test\"}},\"strategy\":{},\"template\":{\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"test\"}},\"spec\":{\"containers\":[{\"image\":\"nginx\",\"name\":\"nginx\",\"resources\":{}}]}}},\"status\":{}}"),
+				Check:  resource.TestCheckOutput("check", "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"test\"},\"name\":\"test\",\"namespace\":\"test-basic\"},\"spec\":{\"replicas\":5,\"selector\":{\"matchLabels\":{\"app\":\"test\"}},\"strategy\":{},\"template\":{\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"test\"}},\"spec\":{\"containers\":[{\"image\":\"nginx\",\"name\":\"nginx\",\"resources\":{}}]}}},\"status\":{}}\n"),
 			},
 		},
 	})
@@ -666,8 +666,8 @@ func TestDataSourceKustomizationOverlay_secretGenerator(t *testing.T) {
 			{
 				Config: testKustomizationSecretGeneratorConfig(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckOutput("check_cm1", "{\"apiVersion\":\"v1\",\"data\":{\"KEY1\":\"VkFMVUUx\",\"KEY2\":\"VkFMVUUy\"},\"kind\":\"Secret\",\"metadata\":{\"name\":\"test-secret1\"},\"type\":\"Opaque\"}"),
-					resource.TestCheckOutput("check_cm2", "{\"apiVersion\":\"v1\",\"data\":{\"ENV1\":\"VkFMVUUx\",\"ENV2\":\"VkFMVUUy\",\"KEY1\":\"VkFMVUUx\",\"KEY2\":\"VkFMVUUy\",\"properties.env\":\"RU5WMT1WQUxVRTEKRU5WMj1WQUxVRTIK\"},\"kind\":\"Secret\",\"metadata\":{\"name\":\"test-secret2-h55cfd6gfg\"},\"type\":\"Opaque\"}"),
+					resource.TestCheckOutput("check_cm1", "{\"apiVersion\":\"v1\",\"data\":{\"KEY1\":\"VkFMVUUx\",\"KEY2\":\"VkFMVUUy\"},\"kind\":\"Secret\",\"metadata\":{\"name\":\"test-secret1\"},\"type\":\"Opaque\"}\n"),
+					resource.TestCheckOutput("check_cm2", "{\"apiVersion\":\"v1\",\"data\":{\"ENV1\":\"VkFMVUUx\",\"ENV2\":\"VkFMVUUy\",\"KEY1\":\"VkFMVUUx\",\"KEY2\":\"VkFMVUUy\",\"properties.env\":\"RU5WMT1WQUxVRTEKRU5WMj1WQUxVRTIK\"},\"kind\":\"Secret\",\"metadata\":{\"name\":\"test-secret2-h55cfd6gfg\"},\"type\":\"Opaque\"}\n"),
 				),
 			},
 		},
@@ -726,7 +726,7 @@ func TestDataSourceKustomizationOverlay_vars(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testKustomizationVarsConfig(),
-				Check:  resource.TestCheckOutput("check", "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"test\"},\"name\":\"test\",\"namespace\":\"test-basic\"},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"test\"}},\"strategy\":{},\"template\":{\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"test\"}},\"spec\":{\"containers\":[{\"env\":[{\"name\":\"TESTENV\",\"value\":\"test-basic\"}],\"image\":\"nginx\",\"name\":\"nginx\",\"resources\":{}}]}}},\"status\":{}}"),
+				Check:  resource.TestCheckOutput("check", "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"test\"},\"name\":\"test\",\"namespace\":\"test-basic\"},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"test\"}},\"strategy\":{},\"template\":{\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"test\"}},\"spec\":{\"containers\":[{\"env\":[{\"name\":\"TESTENV\",\"value\":\"test-basic\"}],\"image\":\"nginx\",\"name\":\"nginx\",\"resources\":{}}]}}},\"status\":{}}\n"),
 			},
 		},
 	})
@@ -805,8 +805,8 @@ func TestDataSourceKustomizationOverlay_module(t *testing.T) {
 			{
 				Config: testKustomizationOverlayConfig_module(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckOutput("check_dep", "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{\"test-annotation\":\"true\"},\"labels\":{\"app\":\"test\",\"test-label\":\"true\"},\"name\":\"tp-test-ts\",\"namespace\":\"test-module\"},\"spec\":{\"replicas\":9,\"selector\":{\"matchLabels\":{\"app\":\"test\",\"test-label\":\"true\"}},\"strategy\":{},\"template\":{\"metadata\":{\"annotations\":{\"test-annotation\":\"true\"},\"labels\":{\"app\":\"test\",\"test-label\":\"true\"}},\"spec\":{\"containers\":[{\"env\":[{\"name\":\"TESTENV\",\"value\":\"true\"},{\"name\":\"TESTVAR\",\"value\":\"tp-os-ts-46f8b28mk5\"}],\"image\":\"test\",\"name\":\"nginx\",\"resources\":{}}]}}},\"status\":{}}"),
-					resource.TestCheckOutput("check_cm", "{\"apiVersion\":\"v1\",\"data\":{\"KEY1\":\"VALUE1\"},\"kind\":\"ConfigMap\",\"metadata\":{\"annotations\":{\"kustomize_generated\":\"true\",\"test-annotation\":\"true\"},\"labels\":{\"test-label\":\"true\"},\"name\":\"tp-ocm-ts\",\"namespace\":\"test-module\"}}"),
+					resource.TestCheckOutput("check_dep", "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{\"test-annotation\":\"true\"},\"labels\":{\"app\":\"test\",\"test-label\":\"true\"},\"name\":\"tp-test-ts\",\"namespace\":\"test-module\"},\"spec\":{\"replicas\":9,\"selector\":{\"matchLabels\":{\"app\":\"test\",\"test-label\":\"true\"}},\"strategy\":{},\"template\":{\"metadata\":{\"annotations\":{\"test-annotation\":\"true\"},\"labels\":{\"app\":\"test\",\"test-label\":\"true\"}},\"spec\":{\"containers\":[{\"env\":[{\"name\":\"TESTENV\",\"value\":\"true\"},{\"name\":\"TESTVAR\",\"value\":\"tp-os-ts-8226t8dd99\"}],\"image\":\"test\",\"name\":\"nginx\",\"resources\":{}}]}}},\"status\":{}}\n"),
+					resource.TestCheckOutput("check_cm", "{\"apiVersion\":\"v1\",\"data\":{\"KEY1\":\"VALUE1\"},\"kind\":\"ConfigMap\",\"metadata\":{\"annotations\":{\"kustomize_generated\":\"true\",\"test-annotation\":\"true\"},\"labels\":{\"test-label\":\"true\"},\"name\":\"tp-ocm-ts\",\"namespace\":\"test-module\"}}\n"),
 				),
 			},
 		},
@@ -901,7 +901,7 @@ output "check_cm" {
 }
 
 output "check_s" {
-	value = module.test.kustomization.manifests["~G_v1_Secret|test-module|tp-os-ts-46f8b28mk5"]
+	value = module.test.kustomization.manifests["~G_v1_Secret|test-module|tp-os-ts-8226t8dd99"]
 }
 `, modulePath, modulePath)
 }


### PR DESCRIPTION
Upstream: https://github.com/kubernetes-sigs/kustomize/issues/3614