### PR TITLE
Handle the dynamic Kustomize overlay in memory

### DIFF
--- a/kustomize/data_source_kustomization_overlay_fs.go
+++ b/kustomize/data_source_kustomization_overlay_fs.go
@@ -1,0 +1,120 @@
+package kustomize
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/kustomize/api/filesys"
+)
+
+var KFILENAME string = "Kustomization"
+
+var _ filesys.FileSystem = overlayFileSystem{}
+
+type overlayFileSystem struct {
+	upper filesys.FileSystem
+	lower filesys.FileSystem
+}
+
+// When two kustmization_overlay data sources are defined in the same root module the shared
+// file system prevents parallel execution.
+// This filesys.FileSystem implementation solves this by handling the dynamic Kustomization in memory.
+func makeOverlayFS(upper filesys.FileSystem, lower filesys.FileSystem) filesys.FileSystem {
+	return overlayFileSystem{
+		upper: upper,
+		lower: lower,
+	}
+}
+
+func (ofs overlayFileSystem) Create(name string) (filesys.File, error) {
+	return ofs.upper.Create(name)
+}
+
+func (ofs overlayFileSystem) Mkdir(name string) error {
+	return ofs.upper.Mkdir(name)
+}
+
+func (ofs overlayFileSystem) MkdirAll(name string) error {
+	return ofs.upper.MkdirAll(name)
+}
+
+func (ofs overlayFileSystem) RemoveAll(name string) error {
+	return ofs.upper.RemoveAll(name)
+}
+
+func (ofs overlayFileSystem) Open(name string) (filesys.File, error) {
+	of, err := ofs.lower.Open(name)
+
+	if err != nil {
+		return ofs.upper.Open(name)
+	}
+
+	return of, err
+}
+
+func (ofs overlayFileSystem) CleanedAbs(path string) (filesys.ConfirmedDir, string, error) {
+	cd, n, err := ofs.lower.CleanedAbs(path)
+
+	if err != nil && strings.HasSuffix(path, KFILENAME) {
+		cd, _, err = ofs.lower.CleanedAbs(".")
+		return cd, KFILENAME, err
+	}
+
+	return cd, n, err
+}
+
+func (ofs overlayFileSystem) Exists(name string) bool {
+	onDisk := ofs.lower.Exists(name)
+
+	if onDisk == false {
+		return ofs.upper.Exists(name)
+	}
+
+	return onDisk
+}
+
+func (ofs overlayFileSystem) Glob(pattern string) ([]string, error) {
+	lfs, err := ofs.lower.Glob(pattern)
+	if err != nil {
+		return lfs, err
+	}
+
+	// Glob only errors if the pattern is invalid
+	ufs, _ := ofs.lower.Glob(pattern)
+
+	return append(lfs, ufs...), nil
+
+}
+
+func (ofs overlayFileSystem) IsDir(name string) bool {
+	exl := ofs.lower.IsDir(name)
+
+	if exl == false {
+		return ofs.upper.IsDir(name)
+	}
+
+	return exl
+}
+
+func (ofs overlayFileSystem) ReadFile(name string) ([]byte, error) {
+	d, err := ofs.lower.ReadFile(name)
+
+	if err != nil && strings.HasSuffix(name, KFILENAME) {
+		return ofs.upper.ReadFile(KFILENAME)
+	}
+
+	return d, err
+}
+
+func (ofs overlayFileSystem) WriteFile(name string, c []byte) error {
+	if ofs.lower.Exists(name) {
+		return fmt.Errorf("OverlayFS: %q already exists in lower FS.", name)
+	}
+
+	return ofs.upper.WriteFile(name, c)
+}
+
+func (ofs overlayFileSystem) Walk(path string, walkFn filepath.WalkFunc) error {
+	return ofs.lower.Walk(path, walkFn)
+}

--- a/kustomize/data_source_kustomization_overlay_fs_test.go
+++ b/kustomize/data_source_kustomization_overlay_fs_test.go
@@ -1,0 +1,267 @@
+package kustomize
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/kustomize/api/filesys"
+)
+
+//
+//
+// Test namespace attr
+func TestOverlayFileSystemTwoDataSources(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testOverlayFileSystemTwoDataSourcesConfig(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckOutput("check1", "{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"name\":\"test-overlay1\"}}\n"),
+					resource.TestCheckOutput("check2", "{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"name\":\"test-overlay2\"}}\n"),
+				),
+			},
+		},
+	})
+}
+
+func testOverlayFileSystemTwoDataSourcesConfig() string {
+	return `
+data "kustomization_overlay" "test1" {
+	namespace = "test-overlay1"
+
+	resources = [
+		"test_kustomizations/basic/initial",
+	]
+}
+
+data "kustomization_overlay" "test2" {
+	namespace = "test-overlay2"
+
+	resources = [
+		"test_kustomizations/basic/initial",
+	]
+}
+
+output "check1" {
+	value = data.kustomization_overlay.test1.manifests["~G_v1_Namespace|~X|test-overlay1"]
+}
+
+output "check2" {
+	value = data.kustomization_overlay.test2.manifests["~G_v1_Namespace|~X|test-overlay2"]
+}
+
+`
+}
+
+//
+//
+// Unit tests
+func TestOverlayFileSystemCreate(t *testing.T) {
+	mfs := filesys.MakeFsInMemory()
+	dfs := filesys.MakeFsOnDisk()
+
+	ofs := makeOverlayFS(mfs, dfs)
+
+	_, err := ofs.Create(KFILENAME)
+	defer ofs.RemoveAll(KFILENAME)
+	assert.Equal(t, nil, err, nil)
+
+	existsOnDisk := dfs.Exists(KFILENAME)
+	assert.Equal(t, false, existsOnDisk, nil)
+
+	existsInMem := mfs.Exists(KFILENAME)
+	assert.Equal(t, true, existsInMem, nil)
+}
+
+func TestOverlayFileSystemMkdir(t *testing.T) {
+	name := "test-mkdir"
+	mfs := filesys.MakeFsInMemory()
+	dfs := filesys.MakeFsOnDisk()
+
+	ofs := makeOverlayFS(mfs, dfs)
+
+	err := ofs.Mkdir(name)
+	defer ofs.RemoveAll(name)
+	assert.Equal(t, nil, err, nil)
+
+	existsOnDisk := dfs.Exists(name)
+	assert.Equal(t, false, existsOnDisk, nil)
+
+	existsInMem := mfs.Exists(name)
+	assert.Equal(t, true, existsInMem, nil)
+}
+
+func TestOverlayFileSystemMkdirAll(t *testing.T) {
+	name := "test-mkdirall/test"
+	mfs := filesys.MakeFsInMemory()
+	dfs := filesys.MakeFsOnDisk()
+
+	ofs := makeOverlayFS(mfs, dfs)
+
+	err := ofs.MkdirAll(name)
+	defer ofs.RemoveAll(name)
+	assert.Equal(t, nil, err, nil)
+
+	existsOnDisk := dfs.Exists(name)
+	assert.Equal(t, false, existsOnDisk, nil)
+
+	existsInMem := mfs.Exists(name)
+	assert.Equal(t, true, existsInMem, nil)
+}
+
+func TestOverlayFileSystemRemoveAll(t *testing.T) {
+	name := "test-mkdirall/test"
+	mfs := filesys.MakeFsInMemory()
+	dfs := filesys.MakeFsOnDisk()
+
+	ofs := makeOverlayFS(mfs, dfs)
+
+	ofs.MkdirAll(name)
+	err := ofs.RemoveAll(name)
+	assert.Equal(t, nil, err, nil)
+
+	existsOnDisk := dfs.Exists(name)
+	assert.Equal(t, false, existsOnDisk, nil)
+
+	existsInMem := mfs.Exists(name)
+	assert.Equal(t, false, existsInMem, nil)
+}
+
+func TestOverlayFileSystemOpen(t *testing.T) {
+	mfs := filesys.MakeFsInMemory()
+	dfs := filesys.MakeFsOnDisk()
+
+	ofs := makeOverlayFS(mfs, dfs)
+
+	ofs.Create(KFILENAME)
+	defer ofs.RemoveAll(KFILENAME)
+
+	_, err := ofs.Open(KFILENAME)
+	assert.Equal(t, nil, err, nil)
+
+	_, err = mfs.Open(KFILENAME)
+	assert.Equal(t, nil, err, nil)
+
+	_, err = dfs.Open(KFILENAME)
+	assert.NotEqual(t, nil, err, nil)
+}
+
+func TestOverlayFileSystemCleanedAbs(t *testing.T) {
+	mfs := filesys.MakeFsInMemory()
+	dfs := filesys.MakeFsOnDisk()
+
+	ofs := makeOverlayFS(mfs, dfs)
+
+	ofs.Create(KFILENAME)
+	defer ofs.RemoveAll(KFILENAME)
+
+	dcd, dn, derr := dfs.CleanedAbs(".")
+	assert.Equal(t, "", dn, nil)
+	assert.Equal(t, nil, derr, nil)
+
+	ocd, on, oerr := ofs.CleanedAbs(KFILENAME)
+	assert.Equal(t, dcd, ocd, nil)
+	assert.Equal(t, KFILENAME, on, nil)
+	assert.Equal(t, nil, oerr, nil)
+
+	mcd, mn, merr := mfs.CleanedAbs(KFILENAME)
+	assert.Equal(t, filesys.ConfirmedDir("/"), mcd, nil)
+	assert.Equal(t, KFILENAME, mn, nil)
+	assert.Equal(t, nil, merr, nil)
+
+	_, _, ederr := dfs.CleanedAbs(KFILENAME)
+	assert.NotEqual(t, nil, ederr, nil)
+}
+
+func TestOverlayFileSystemExists(t *testing.T) {
+	mfs := filesys.MakeFsInMemory()
+	dfs := filesys.MakeFsOnDisk()
+
+	ofs := makeOverlayFS(mfs, dfs)
+
+	ofs.Create(KFILENAME)
+	defer ofs.RemoveAll(KFILENAME)
+
+	c := ofs.Exists(KFILENAME)
+	assert.Equal(t, true, c, nil)
+}
+
+func TestOverlayFileSystemGlob(t *testing.T) {
+	mfs := filesys.MakeFsInMemory()
+	dfs := filesys.MakeFsOnDisk()
+
+	ofs := makeOverlayFS(mfs, dfs)
+
+	ofs.Create(KFILENAME)
+	defer ofs.RemoveAll(KFILENAME)
+
+	r, err := ofs.Glob(KFILENAME)
+	assert.Equal(t, []string(nil), r, nil)
+	assert.Equal(t, nil, err, nil)
+}
+
+func TestOverlayFileSystemIsDir(t *testing.T) {
+	name := "test_kustomizations"
+	mfs := filesys.MakeFsInMemory()
+	dfs := filesys.MakeFsOnDisk()
+
+	ofs := makeOverlayFS(mfs, dfs)
+
+	mc := mfs.IsDir(name)
+	assert.Equal(t, false, mc, nil)
+
+	dc := dfs.IsDir(name)
+	assert.Equal(t, true, dc, nil)
+
+	oc := ofs.IsDir(name)
+	assert.Equal(t, dc, oc, nil)
+}
+
+func TestOverlayFileSystemReadFile(t *testing.T) {
+	mfs := filesys.MakeFsInMemory()
+	dfs := filesys.MakeFsOnDisk()
+
+	ofs := makeOverlayFS(mfs, dfs)
+	ofs.Create(KFILENAME)
+	defer ofs.RemoveAll(KFILENAME)
+
+	od, oerr := ofs.ReadFile(KFILENAME)
+	assert.Equal(t, []byte{}, od, nil)
+	assert.Equal(t, nil, oerr, nil)
+
+	md, merr := mfs.ReadFile(KFILENAME)
+	assert.Equal(t, []byte{}, md, nil)
+	assert.Equal(t, nil, merr, nil)
+
+	dd, derr := dfs.ReadFile(KFILENAME)
+	assert.Equal(t, []byte(nil), dd, nil)
+	assert.NotEqual(t, nil, derr, nil)
+}
+
+func TestOverlayFileSystemWriteFile(t *testing.T) {
+	mfs := filesys.MakeFsInMemory()
+	dfs := filesys.MakeFsOnDisk()
+
+	ed := []byte("test")
+
+	ofs := makeOverlayFS(mfs, dfs)
+	oerr := ofs.WriteFile(KFILENAME, ed)
+	defer ofs.RemoveAll(KFILENAME)
+	assert.Equal(t, nil, oerr, nil)
+
+	od, oerr := ofs.ReadFile(KFILENAME)
+	assert.Equal(t, ed, od, nil)
+	assert.Equal(t, nil, oerr, nil)
+
+	md, merr := mfs.ReadFile(KFILENAME)
+	assert.Equal(t, ed, md, nil)
+	assert.Equal(t, nil, merr, nil)
+
+	dd, derr := dfs.ReadFile(KFILENAME)
+	assert.Equal(t, []byte(nil), dd, nil)
+	assert.NotEqual(t, nil, derr, nil)
+}


### PR DESCRIPTION
The shared FS and Terraform's prallelism otherwise prevent two
kustomization_overlay data sources in the same root module.