### PR TITLE
Fall back to MergePatch if StrategicMergePatch returns invalid fix #86

### DIFF
--- a/kustomize/resource_kustomization_test.go
+++ b/kustomize/resource_kustomization_test.go
@@ -199,6 +199,65 @@ resource "kustomization_resource" "dep1" {
 
 //
 //
+// Update_Merge_Fallback Test
+func TestAccResourceKustomization_updateMergeFallback(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			//
+			//
+			// Applying initial config with env set by a value
+			{
+				Config: testAccResourceKustomizationConfig_updateMergeFallbackInitial("test_kustomizations/update_merge_fallback/initial"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("kustomization_resource.ns", "id"),
+					resource.TestCheckResourceAttrSet("kustomization_resource.svc", "id"),
+					resource.TestCheckResourceAttrSet("kustomization_resource.dep", "id"),
+				),
+			},
+			//
+			//
+			// Applying modified config replacing env value with valueFrom
+			{
+				Config: testAccResourceKustomizationConfig_updateMergeFallbackModified("test_kustomizations/update_merge_fallback/modified"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("kustomization_resource.ns", "id"),
+					resource.TestCheckResourceAttrSet("kustomization_resource.svc", "id"),
+					resource.TestCheckResourceAttrSet("kustomization_resource.dep", "id"),
+					resource.TestCheckResourceAttrSet("kustomization_resource.cm", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceKustomizationConfig_updateMergeFallbackInitial(path string) string {
+	return testAccDataSourceKustomizationConfig_basic(path) + `
+resource "kustomization_resource" "ns" {
+	manifest = data.kustomization_build.test.manifests["~G_v1_Namespace|~X|test-update-merge-fallback"]
+}
+
+resource "kustomization_resource" "svc" {
+	manifest = data.kustomization_build.test.manifests["~G_v1_Service|test-update-merge-fallback|test"]
+}
+
+resource "kustomization_resource" "dep" {
+	manifest = data.kustomization_build.test.manifests["apps_v1_Deployment|test-update-merge-fallback|test"]
+}
+`
+}
+
+func testAccResourceKustomizationConfig_updateMergeFallbackModified(path string) string {
+	return testAccResourceKustomizationConfig_updateMergeFallbackInitial(path) + `
+resource "kustomization_resource" "cm" {
+	manifest = data.kustomization_build.test.manifests["~G_v1_ConfigMap|test-update-merge-fallback|test-envfrom-kmdg664296"]
+}
+`
+}
+
+//
+//
 // Update_Recreate Test
 func TestAccResourceKustomization_updateRecreate(t *testing.T) {
 

--- a/kustomize/test_kustomizations/update_merge_fallback/initial/kustomization.yaml
+++ b/kustomize/test_kustomizations/update_merge_fallback/initial/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: test-update-merge-fallback
+
+resources:
+- namespace.yaml
+- ../../_example_app
+
+patches:
+- path: patch_deployment_env.yaml

--- a/kustomize/test_kustomizations/update_merge_fallback/initial/namespace.yaml
+++ b/kustomize/test_kustomizations/update_merge_fallback/initial/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-update-merge-fallback

--- a/kustomize/test_kustomizations/update_merge_fallback/initial/patch_deployment_env.yaml
+++ b/kustomize/test_kustomizations/update_merge_fallback/initial/patch_deployment_env.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        env:
+        - name: TEST_ENV
+          value: "1"

--- a/kustomize/test_kustomizations/update_merge_fallback/modified/kustomization.yaml
+++ b/kustomize/test_kustomizations/update_merge_fallback/modified/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: test-update-merge-fallback
+
+configMapGenerator:
+  - name: test-envfrom
+    literals:
+      - "env=KEY1=VALUE1\nKEY2=VALUE2\n"
+
+resources:
+- namespace.yaml
+- ../../_example_app
+
+patches:
+  - path: patch_deployment_envfrom.yaml

--- a/kustomize/test_kustomizations/update_merge_fallback/modified/namespace.yaml
+++ b/kustomize/test_kustomizations/update_merge_fallback/modified/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-update-merge-fallback

--- a/kustomize/test_kustomizations/update_merge_fallback/modified/patch_deployment_envfrom.yaml
+++ b/kustomize/test_kustomizations/update_merge_fallback/modified/patch_deployment_envfrom.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        env:
+        - name: TEST_ENV
+          valueFrom:
+            configMapKeyRef:
+              name: test-envfrom
+              key: env


### PR DESCRIPTION
We try `StrategicMergePatch` first and are supposed to fall back to `MergePatch` when `StrategicMergePatch`
is not an option. But previously we would only try `MergePatch` if the error returned was explicitly
`UnsupportedMediaType`.

However, if the API returns Invalid for `StrategicMergePatch` we have to try `MergePatch` before returning
an error to the user.