### PR TITLE
Refuse to import resources without LastAppliedConfigAnnotation fix #85

### DIFF
--- a/kustomize/resource_kustomization.go
+++ b/kustomize/resource_kustomization.go
@@ -505,7 +505,14 @@ func kustomizationResourceImport(d *schema.ResourceData, m interface{}) ([]*sche
 	id := string(resp.GetUID())
 	d.SetId(id)
 
-	d.Set("manifest", getLastAppliedConfig(resp))
+	lac := getLastAppliedConfig(resp)
+	if lac == "" {
+		return nil, logError(
+			fmt.Errorf("apiVersion: %q, kind: %q, namespace: %q, name: %q: can not import resources without %q annotation", gvk.GroupVersion(), gvk.Kind, namespace, name, lastAppliedConfig),
+		)
+	}
+
+	d.Set("manifest", lac)
 
 	return []*schema.ResourceData{d}, nil
 }


### PR DESCRIPTION
The provider relies on the same LastAppliedConfigAnnotation as kubectl. This
was a decision I made early, that may very well have been unnecessary and
could be changed going forward.

However, I do not currently have the time to look into what this means,
especially for diff output and existing states.

For now, I make the limitation explicit by returning a descript error
during import, instead of failing with a non-descript JSON parse error.