### PR TITLE
Add architecture args to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 build:
-	go build -o terraform.d/plugins/registry.terraform.io/kbst/kustomization/1.0.0/linux_amd64/terraform-provider-kustomization
+	GOOS=linux GOARCH=amd64 go build -o terraform.d/plugins/registry.terraform.io/kbst/kustomization/1.0.0/linux_amd64/terraform-provider-kustomization
 
 test:
 	TF_ACC=1 go test -v ./kustomize


### PR DESCRIPTION
This is pretty brittle, but at least will make the binary arch match the folder name