### PR TITLE
Add Mutex to serialize Kustomizer runs - workaround #91

### DIFF
--- a/kustomize/data_source_kustomization_build.go
+++ b/kustomize/data_source_kustomization_build.go
@@ -46,7 +46,13 @@ func kustomizationBuild(d *schema.ResourceData, m interface{}) error {
 	path := d.Get("path").(string)
 
 	fSys := filesys.MakeFsOnDisk()
+
+	// mutex as tmp workaround for upstream bug
+	// https://github.com/kubernetes-sigs/kustomize/issues/3659
+	mu := m.(*Config).Mutex
+	mu.Lock()
 	rm, err := runKustomizeBuild(fSys, path)
+	mu.Unlock()
 	if err != nil {
 		return fmt.Errorf("kustomizationBuild: %s", err)
 	}

--- a/kustomize/data_source_kustomization_overlay.go
+++ b/kustomize/data_source_kustomization_overlay.go
@@ -687,7 +687,12 @@ func kustomizationOverlay(d *schema.ResourceData, m interface{}) error {
 	fSys.WriteFile(KFILENAME, data)
 	defer fSys.RemoveAll(KFILENAME)
 
+	// mutex as tmp workaround for upstream bug
+	// https://github.com/kubernetes-sigs/kustomize/issues/3659
+	mu := m.(*Config).Mutex
+	mu.Lock()
 	rm, err := runKustomizeBuild(fSys, ".")
+	mu.Unlock()
 	if err != nil {
 		return fmt.Errorf("buildKustomizeOverlay: %s", err)
 	}


### PR DESCRIPTION
This mutex prevents multiple Kustomizer runs in parallel
to avoid the `concurrent map read and map write` bug from
upstream.

https://github.com/kubernetes-sigs/kustomize/issues/3659