### PR TITLE
Add test updating apiVersion fix #93

### DIFF
--- a/kustomize/test_kustomizations/update_api_version/initial/co.yaml
+++ b/kustomize/test_kustomizations/update_api_version/initial/co.yaml
@@ -1,0 +1,6 @@
+apiVersion: test.example.com/v1
+kind: Versionupdate
+metadata:
+  name: vuco
+  namespace: test-update-api-version
+spec: {}

--- a/kustomize/test_kustomizations/update_api_version/initial/crd.yaml
+++ b/kustomize/test_kustomizations/update_api_version/initial/crd.yaml
@@ -1,0 +1,33 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: versionupdates.test.example.com
+spec:
+  group: test.example.com
+  names:
+    kind: Versionupdate
+    plural: versionupdates
+    shortNames:
+    - vu
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties: {}
+  - name: v2
+    served: true
+    storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties: {}

--- a/kustomize/test_kustomizations/update_api_version/initial/kustomization.yaml
+++ b/kustomize/test_kustomizations/update_api_version/initial/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: test-update-api-version
+
+resources:
+- namespace.yaml
+- crd.yaml
+- co.yaml

--- a/kustomize/test_kustomizations/update_api_version/initial/namespace.yaml
+++ b/kustomize/test_kustomizations/update_api_version/initial/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-update-api-version

--- a/kustomize/test_kustomizations/update_api_version/modified/kustomization.yaml
+++ b/kustomize/test_kustomizations/update_api_version/modified/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: test-update-api-version
+
+resources:
+- ../initial
+
+patches:
+- patch: |
+    - op: replace
+      path: /apiVersion
+      value: test.example.com/v2
+  target:
+    group: test.example.com
+    version: v1
+    kind: Versionupdate
+    name: vuco
+    namespace: test-update-api-version

--- a/kustomize/test_kustomizations/update_api_version/modified/namespace.yaml
+++ b/kustomize/test_kustomizations/update_api_version/modified/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-update-api-version


### PR DESCRIPTION
Experiment to make apiVersion updates an in-place instead of a destroy and re-create plan.

Related issue: https://github.com/kbst/terraform-provider-kustomization/issues/93