### PR TITLE
Avoid whitespace changes from data sources

### DIFF
--- a/kustomize/util.go
+++ b/kustomize/util.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"strings"
 
 	k8scorev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -31,7 +32,8 @@ func setLastAppliedConfig(u *k8sunstructured.Unstructured, srcJSON string) {
 }
 
 func getLastAppliedConfig(u *k8sunstructured.Unstructured) string {
-	return u.GetAnnotations()[lastAppliedConfig]
+	// ensure that lastAppliedConfig definitely ends in one and only one newline
+	return fmt.Sprintf("%s\n", strings.TrimRight(u.GetAnnotations()[lastAppliedConfig], "\r\n"))
 }
 
 func getOriginalModifiedCurrent(originalJSON string, modifiedJSON string, currentAllowNotFound bool, m interface{}) (original []byte, modified []byte, current []byte, err error) {

--- a/kustomize/util_test.go
+++ b/kustomize/util_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestLastAppliedConfig(t *testing.T) {
-	srcJSON := "{\"apiVersion\": \"v1\", \"kind\": \"Namespace\", \"metadata\": {\"name\": \"test-unit\"}}"
+	srcJSON := "{\"apiVersion\": \"v1\", \"kind\": \"Namespace\", \"metadata\": {\"name\": \"test-unit\"}}\n"
 	u, err := parseJSON(srcJSON)
 	if err != nil {
 		t.Errorf("Error: %s", err)


### PR DESCRIPTION
There is a mismatch between the resource that is built by
the build and overlay kustomization data sources and the
resource information returned by kubernetes.

This seems to show up after first import only, but it's worth
being consistent

Because we use a yaml.Encoder to provide the manifest to
send to kubernetes, it ends in a trailing newline (and this
is reflected in the test suite). However, the current state
is pulled from lastAppliedConfig which doesn't have that
whitespace, and so the resources appear to mismatch and need
updating.

Adding a trailing new line to the existing state before the
compare seems to minimise required changes.