### PR TITLE
Allow debugging of kustomization provider

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,15 +1,34 @@
 package main
 
 import (
+	"context"
+	"flag"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/kbst/terraform-provider-kustomize/kustomize"
 )
 
 func main() {
-	plugin.Serve(&plugin.ServeOpts{
+	var debugMode bool
+
+	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
+	opts := &plugin.ServeOpts{
 		ProviderFunc: func() terraform.ResourceProvider {
 			return kustomize.Provider()
 		},
-	})
+	}
+
+	if debugMode {
+		err := plugin.Debug(context.Background(), "registry.terraform.io/kbst/kustomization", opts)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		return
+	}
+
+	plugin.Serve(opts)
 }


### PR DESCRIPTION
Pass `--debug` to turn on debugging mode as per:

https://www.terraform.io/docs/extend/debugging.html