### PR TITLE
ForceNew when name or namespace change without state ID change fix #132

### DIFF
--- a/kustomize/resource_kustomization_test.go
+++ b/kustomize/resource_kustomization_test.go
@@ -331,6 +331,62 @@ resource "kustomization_resource" "dep1" {
 
 //
 //
+// Update_Recreate_Name_Or_Namespace_Change Test
+func TestAccResourceKustomization_updateRecreateNameOrNamespaceChange(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			//
+			//
+			// Applying initial config with a svc and deployment in a namespace
+			{
+				Config: testAccResourceKustomizationConfig_updateRecreateNameOrNamespaceChange("test_kustomizations/update_recreate_name_or_namespace_change/initial"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("kustomization_resource.ns", "id"),
+					resource.TestCheckResourceAttrSet("kustomization_resource.cm", "id"),
+				),
+			},
+			//
+			//
+			// Applying modified config changing the immutable label selectors
+			{
+				Config: testAccResourceKustomizationConfig_updateRecreateNameOrNamespaceChangeModified("test_kustomizations/update_recreate_name_or_namespace_change/modified"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("kustomization_resource.ns", "id"),
+					resource.TestCheckResourceAttrSet("kustomization_resource.cm", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceKustomizationConfig_updateRecreateNameOrNamespaceChange(path string) string {
+	return testAccDataSourceKustomizationConfig_basic(path) + `
+resource "kustomization_resource" "ns" {
+	manifest = data.kustomization_build.test.manifests["~G_v1_Namespace|~X|test-update-recreate-name-or-namespace-change"]
+}
+
+resource "kustomization_resource" "cm" {
+	manifest = data.kustomization_build.test.manifests["~G_v1_ConfigMap|test-update-recreate-name-or-namespace-change|test"]
+}
+`
+}
+
+func testAccResourceKustomizationConfig_updateRecreateNameOrNamespaceChangeModified(path string) string {
+	return testAccDataSourceKustomizationConfig_basic(path) + `
+resource "kustomization_resource" "ns" {
+	manifest = data.kustomization_build.test.manifests["~G_v1_Namespace|~X|test-update-recreate-name-or-namespace-change-modified"]
+}
+
+resource "kustomization_resource" "cm" {
+	manifest = data.kustomization_build.test.manifests["~G_v1_ConfigMap|test-update-recreate-name-or-namespace-change-modified|test"]
+}
+`
+}
+
+//
+//
 // Update_Recreate_StatefulSet Test
 func TestAccResourceKustomization_updateRecreateStatefulSet(t *testing.T) {
 

--- a/kustomize/test_kustomizations/update_recreate_name_or_namespace_change/initial/kustomization.yaml
+++ b/kustomize/test_kustomizations/update_recreate_name_or_namespace_change/initial/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: test-update-recreate-name-or-namespace-change
+
+resources:
+- namespace.yaml
+
+configMapGenerator:
+- name: test
+  options:
+    disableNameSuffixHash: true

--- a/kustomize/test_kustomizations/update_recreate_name_or_namespace_change/initial/namespace.yaml
+++ b/kustomize/test_kustomizations/update_recreate_name_or_namespace_change/initial/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-update-recreate-name-or-namespace-change

--- a/kustomize/test_kustomizations/update_recreate_name_or_namespace_change/modified/kustomization.yaml
+++ b/kustomize/test_kustomizations/update_recreate_name_or_namespace_change/modified/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: test-update-recreate-name-or-namespace-change-modified
+
+resources:
+- ../initial


### PR DESCRIPTION
This issue is rare, because when using `for_each` the state ID will
always change when the name or namespace change.

But when not using `for_each` Terraform will run the diff func and
it can't rely on the dry-run because that will return errors
when the name and namespace in the URL differ from the manifest.