### PR TITLE
Avoid panic when running test suite on OS X

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kbst/terraform-provider-kustomize
 
-go 1.12
+go 1.16
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
@@ -13,3 +13,5 @@ require (
 	sigs.k8s.io/kustomize/api v0.10.0
 	sigs.k8s.io/kustomize/kyaml v0.12.0
 )
+
+require golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -691,8 +691,9 @@ golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201112073958-5cba982894dd h1:5CtCZbICpIOFdgO940moixOPjc0178IU44m4EjOO5IY=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 h1:foEbQz/B0Oz6YIqu/69kfXPYeFQAuuMYFkjaqXzl5Wo=
+golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
Update x/sys and go version to eliminate panic

Fixes this stack trace (probably only seen when using the exec plugin in
~/.kube/config)

```
goroutine 107 [syscall]:
syscall.syscall(0x54330c0, 0x1, 0x40487413, 0xc00028b480)
	/usr/local/Cellar/go/1.17.1/libexec/src/runtime/sys_darwin.go:22 +0x3b fp=0xc00028b3f0 sp=0xc00028b3d0 pc=0x406711b
syscall.syscall(0xc00054c900, 0x5a941c0, 0xc000682270, 0xc00028b468)
	<autogenerated>:1 +0x26 fp=0xc00028b438 sp=0xc00028b3f0 pc=0x406d0e6
golang.org/x/sys/unix.ioctl(0x40138f8, 0x54382f3, 0xc00054c960)
	/Users/will/src/go/pkg/mod/golang.org/x/sys@v0.0.0-20201112073958-5cba982894dd/unix/zsyscall_darwin_amd64.go:731 +0x39 fp=0xc00028b468 sp=0xc00028b438 pc=0x5432b19
golang.org/x/sys/unix.IoctlGetTermios(...)
	/Users/will/src/go/pkg/mod/golang.org/x/sys@v0.0.0-20201112073958-5cba982894dd/unix/ioctl.go:72
golang.org/x/crypto/ssh/terminal.IsTerminal(0x5860840)
	/Users/will/src/go/pkg/mod/golang.org/x/crypto@v0.0.0-20201002170205-7f63de1d35b0/ssh/terminal/util.go:30 +0x50 fp=0xc00028b4d8 sp=0xc00028b468 pc=0x54333d0
k8s.io/client-go/plugin/pkg/client/auth/exec.newAuthenticator(0x5b0fb10, 0xc0005f4680, 0x0)
	/Users/will/src/go/pkg/mod/k8s.io/client-go@v0.20.2/plugin/pkg/client/auth/exec/exec.go:196 +0x166 fp=0xc00028b5a8 sp=0xc00028b4d8 pc=0x5438966
k8s.io/client-go/plugin/pkg/client/auth/exec.GetAuthenticator(...)
	/Users/will/src/go/pkg/mod/k8s.io/client-go@v0.20.2/plugin/pkg/client/auth/exec/exec.go:166
k8s.io/client-go/rest.(*Config).TransportConfig(0xc00051d8c0)
	/Users/will/src/go/pkg/mod/k8s.io/client-go@v0.20.2/rest/transport.go:106 +0x508 fp=0xc00028b608 sp=0xc00028b5a8 pc=0x54480a8
k8s.io/client-go/rest.TransportFor(0xc00054c910)
	/Users/will/src/go/pkg/mod/k8s.io/client-go@v0.20.2/rest/transport.go:43 +0x19 fp=0xc00028b620 sp=0xc00028b608 pc=0x5447b59
k8s.io/client-go/rest.RESTClientFor(0xc00051d8c0)
	/Users/will/src/go/pkg/mod/k8s.io/client-go@v0.20.2/rest/config.go:319 +0x74 fp=0xc00028b7b8 sp=0xc00028b620 pc=0x543c534
k8s.io/client-go/dynamic.NewForConfig(0xc0004be000)
	/Users/will/src/go/pkg/mod/k8s.io/client-go@v0.20.2/dynamic/simple.go:69 +0x92 fp=0xc00028b7e8 sp=0xc00028b7b8 pc=0x545dd52
github.com/kbst/terraform-provider-kustomize/kustomize.Provider.func1(0xc0003237d0)
	/Users/will/src/opensource/terraform-provider-kustomization/kustomize/provider.go:129 +0x385 fp=0xc00028bab0 sp=0xc00028b7e8 pc=0x569b925
github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Provider).Configure(0xc00035b900, 0xc000138120)
	/Users/will/src/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.16.0/helper/schema/provider.go:275 +0xb4 fp=0xc00028bb00 sp=0xc00028bab0 pc=0x4a336b4
github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin.(*GRPCProviderServer).Configure(0xc00050a0e0, {0xc0006c46c0, 0x4110726}, 0xc0006c46c0)
	/Users/will/src/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.16.0/internal/helper/plugin/grpc_provider.go:487 +0x1d2 fp=0xc00028bb78 sp=0xc00028bb00 pc=0x54db792
github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5._Provider_Configure_Handler({0x5a6f8e0, 0xc00050a0e0}, {0x5e82408, 0xc00083b380}, 0xc00031cae0, 0x0)
	/Users/will/src/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.16.0/internal/tfplugin5/tfplugin5.pb.go:3251 +0x170 fp=0xc00028bbd0 sp=0xc00028bb78 pc=0x54d36b0
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0006c6700, {0x5ebe2d8, 0xc00069f380}, 0xc0001ae400, 0xc000659e00, 0x6ed5e98, 0x0)
	/Users/will/src/go/pkg/mod/google.golang.org/grpc@v1.30.0/server.go:1171 +0xc8f fp=0xc00028be50 sp=0xc00028bbd0 pc=0x46ab94f
google.golang.org/grpc.(*Server).handleStream(0xc0006c6700, {0x5ebe2d8, 0xc00069f380}, 0xc0001ae400, 0x0)
	/Users/will/src/go/pkg/mod/google.golang.org/grpc@v1.30.0/server.go:1494 +0x9f3 fp=0xc00028bf68 sp=0xc00028be50 pc=0x46af4d3
google.golang.org/grpc.(*Server).serveStreams.func1.2()
	/Users/will/src/go/pkg/mod/google.golang.org/grpc@v1.30.0/server.go:834 +0x98 fp=0xc00028bfe0 sp=0xc00028bf68 pc=0x46a95f8
runtime.goexit()
	/usr/local/Cellar/go/1.17.1/libexec/src/runtime/asm_amd64.s:1581 +0x1 fp=0xc00028bfe8 sp=0xc00028bfe0 pc=0x406aa01
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/Users/will/src/go/pkg/mod/google.golang.org/grpc@v1.30.0/server.go:832 +0x294
```