### PR TITLE
Improve missing API group/kind message

### DIFF
--- a/kustomize/resource_kustomization.go
+++ b/kustomize/resource_kustomization.go
@@ -292,7 +292,7 @@ func kustomizationResourceExists(d *schema.ResourceData, m interface{}) (bool, e
 		if k8smeta.IsNoMatchError(err) {
 			// If the Kind does not exist in the K8s API,
 			// the resource can't exist either
-			return false, nil
+			return false, logError(fmt.Errorf("Can't find kind %s in API group %s", u.GroupVersionKind().Kind, u.GroupVersionKind().Group))
 		}
 		return false, err
 	}


### PR DESCRIPTION
e.g. if trying to import a Deployment that was last configured
using extensions/v1beta1, the error message improves from:

> Error: Cannot import non-existent remote object
>
> While attempting to import an existing object to "kustomization_resource.p1[\"apps/Deployment/test-ns/test-deploy\"]",
> the provider detected that no object exists with the given id. Only pre-existing objects can be
> imported; check that the id is correct and that it is associated with the provider's configured
>  region or endpoint, or use "terraform apply" to create a new remote object for this resource.

to:

> Error: github.com/kbst/terraform-provider-kustomize/kustomize.kustomizationResourceExists: Can't find Deployment in API group extensions