### PR TITLE
Stop relying on lastAppliedConfig annotation fix #94

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: push
 
 env:
   GO_VERSION: ">=1.15"
-  TERRAFORM_VERSION: "0.14.7"
+  TERRAFORM_VERSION: "1.0.11"
 
 jobs:
   tf_tests:

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kbst/terraform-provider-kustomize
 go 1.16
 
 require (
+	github.com/evanphx/json-patch v4.11.0+incompatible
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/stretchr/testify v1.7.0
@@ -13,5 +14,3 @@ require (
 	sigs.k8s.io/kustomize/api v0.10.0
 	sigs.k8s.io/kustomize/kyaml v0.12.0
 )
-
-require golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -143,12 +143,10 @@ github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZM
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fvbommel/sortorder v1.0.1/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -691,9 +689,8 @@ golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201112073958-5cba982894dd h1:5CtCZbICpIOFdgO940moixOPjc0178IU44m4EjOO5IY=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 h1:foEbQz/B0Oz6YIqu/69kfXPYeFQAuuMYFkjaqXzl5Wo=
-golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/kustomize/data_source_kustomization_overlay_test.go
+++ b/kustomize/data_source_kustomization_overlay_test.go
@@ -309,7 +309,7 @@ func TestDataSourceKustomizationOverlay_name_prefix_suffix(t *testing.T) {
 			{
 				Config: testDataSourceKustomizationOverlayConfig_name_prefix_suffix(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckOutput("check", "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"test\"},\"name\":\"test-test-test\",\"namespace\":\"test-basic\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":80}],\"selector\":{\"app\":\"test\"},\"type\":\"ClusterIP\"},\"status\":{\"loadBalancer\":{}}}"),
+					resource.TestCheckOutput("check", "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"labels\":{\"app\":\"test\"},\"name\":\"test-test-test\",\"namespace\":\"test-basic\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":80}],\"selector\":{\"app\":\"test\"},\"type\":\"ClusterIP\"},\"status\":{\"loadBalancer\":{}}}"),
 				),
 			},
 		},
@@ -379,7 +379,7 @@ func TestDataSourceKustomizationOverlay_transformers(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testDataSourceKustomizationOverlayConfig_transformers(),
-				Check:  resource.TestCheckOutput("check", "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"test\",\"test.example.com/test-label\":\"test-value\"},\"name\":\"test\",\"namespace\":\"test-transformer-config\"},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"test\"}},\"strategy\":{},\"template\":{\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"test\"}},\"spec\":{\"containers\":[{\"image\":\"nginx\",\"name\":\"nginx\",\"resources\":{}}]}}},\"status\":{}}"),
+				Check:  resource.TestCheckOutput("check", "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"labels\":{\"app\":\"test\",\"test.example.com/test-label\":\"test-value\"},\"name\":\"test\",\"namespace\":\"test-transformer-config\"},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"test\"}},\"strategy\":{},\"template\":{\"metadata\":{\"labels\":{\"app\":\"test\"}},\"spec\":{\"containers\":[{\"image\":\"nginx\",\"name\":\"nginx\",\"resources\":{}}]}}},\"status\":{}}"),
 			},
 		},
 	})
@@ -531,7 +531,7 @@ func TestDataSourceKustomizationOverlay_images(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testKustomizationImagesConfig(),
-				Check:  resource.TestCheckOutput("check", "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"test\"},\"name\":\"test\",\"namespace\":\"test-basic\"},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"test\"}},\"strategy\":{},\"template\":{\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"test\"}},\"spec\":{\"containers\":[{\"image\":\"testname@sha256:abcdefghijklmnop123456\",\"name\":\"nginx\",\"resources\":{}}]}}},\"status\":{}}"),
+				Check:  resource.TestCheckOutput("check", "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"labels\":{\"app\":\"test\"},\"name\":\"test\",\"namespace\":\"test-basic\"},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"test\"}},\"strategy\":{},\"template\":{\"metadata\":{\"labels\":{\"app\":\"test\"}},\"spec\":{\"containers\":[{\"image\":\"testname@sha256:abcdefghijklmnop123456\",\"name\":\"nginx\",\"resources\":{}}]}}},\"status\":{}}"),
 			},
 		},
 	})
@@ -571,7 +571,7 @@ func TestDataSourceKustomizationOverlay_patches(t *testing.T) {
 				Config: testKustomizationPatchesConfig(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckOutput("check_dep", "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"labels\":{\"app\":\"test\"},\"name\":\"test\",\"namespace\":\"test-basic\"},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"test\"}},\"strategy\":{},\"template\":{\"metadata\":{\"labels\":{\"app\":\"test\"}},\"spec\":{\"containers\":[{\"env\":[{\"name\":\"TESTENV\",\"value\":\"true\"}],\"image\":\"nginx\",\"name\":\"nginx\",\"resources\":{}}]}}},\"status\":{}}"),
-					resource.TestCheckOutput("check_ingress", "{\"apiVersion\":\"networking.k8s.io/v1beta1\",\"kind\":\"Ingress\",\"metadata\":{\"annotations\":{\"nginx.ingress.kubernetes.io/rewrite-target\":\"/\"},\"name\":\"test\",\"namespace\":\"test-basic\"},\"spec\":{\"rules\":[{\"http\":{\"paths\":[{\"backend\":{\"serviceName\":\"test\",\"servicePort\":80},\"path\":\"/newpath\"}]}}]}}"),
+					resource.TestCheckOutput("check_ingress", "{\"apiVersion\":\"networking.k8s.io/v1beta1\",\"kind\":\"Ingress\",\"metadata\":{\"annotations\":{\"nginx.ingress.kubernetes.io/rewrite-target\":\"/\"},\"name\":\"test\",\"namespace\":\"test-basic\"},\"spec\":{\"rules\":[{\"http\":{\"paths\":[{\"backend\":{\"serviceName\":\"test\",\"servicePort\":80},\"path\":\"/newpath\",\"pathType\":\"ImplementationSpecific\"}]}}]}}"),
 				),
 			},
 		},
@@ -630,7 +630,7 @@ func TestDataSourceKustomizationOverlay_replicas(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testKustomizationReplicasConfig(),
-				Check:  resource.TestCheckOutput("check", "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"test\"},\"name\":\"test\",\"namespace\":\"test-basic\"},\"spec\":{\"replicas\":5,\"selector\":{\"matchLabels\":{\"app\":\"test\"}},\"strategy\":{},\"template\":{\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"test\"}},\"spec\":{\"containers\":[{\"image\":\"nginx\",\"name\":\"nginx\",\"resources\":{}}]}}},\"status\":{}}"),
+				Check:  resource.TestCheckOutput("check", "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"labels\":{\"app\":\"test\"},\"name\":\"test\",\"namespace\":\"test-basic\"},\"spec\":{\"replicas\":5,\"selector\":{\"matchLabels\":{\"app\":\"test\"}},\"strategy\":{},\"template\":{\"metadata\":{\"labels\":{\"app\":\"test\"}},\"spec\":{\"containers\":[{\"image\":\"nginx\",\"name\":\"nginx\",\"resources\":{}}]}}},\"status\":{}}"),
 			},
 		},
 	})
@@ -727,7 +727,7 @@ func TestDataSourceKustomizationOverlay_vars(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testKustomizationVarsConfig(),
-				Check:  resource.TestCheckOutput("check", "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"test\"},\"name\":\"test\",\"namespace\":\"test-basic\"},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"test\"}},\"strategy\":{},\"template\":{\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"test\"}},\"spec\":{\"containers\":[{\"env\":[{\"name\":\"TESTENV\",\"value\":\"test-basic\"}],\"image\":\"nginx\",\"name\":\"nginx\",\"resources\":{}}]}}},\"status\":{}}"),
+				Check:  resource.TestCheckOutput("check", "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"labels\":{\"app\":\"test\"},\"name\":\"test\",\"namespace\":\"test-basic\"},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"test\"}},\"strategy\":{},\"template\":{\"metadata\":{\"labels\":{\"app\":\"test\"}},\"spec\":{\"containers\":[{\"env\":[{\"name\":\"TESTENV\",\"value\":\"test-basic\"}],\"image\":\"nginx\",\"name\":\"nginx\",\"resources\":{}}]}}},\"status\":{}}"),
 			},
 		},
 	})

--- a/kustomize/structures_kustomization.go
+++ b/kustomize/structures_kustomization.go
@@ -1,7 +1,14 @@
 package kustomize
 
 import (
+	"fmt"
+	jsonpatch "github.com/evanphx/json-patch"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"sigs.k8s.io/kustomize/api/resmap"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	"k8s.io/kubectl/pkg/scheme"
 )
 
 func flattenKustomizationIDs(rm resmap.ResMap, legacy bool) (ids []string, idsPrio [][]string, err error) {
@@ -51,4 +58,35 @@ func flattenKustomizationResources(rm resmap.ResMap, legacy bool) (res map[strin
 		res[id] = string(json)
 	}
 	return res, nil
+}
+
+func flattenApiResponse(gvk schema.GroupVersionKind, re []byte, ma []byte) (json string, err error) {
+	p, pt, err := getPatch(gvk, re, ma, ma)
+	if err != nil {
+		return json, fmt.Errorf("determining patch failed: %s", err)
+	}
+
+	var out []byte
+	switch pt {
+	case types.MergePatchType:
+		out, err = jsonpatch.MergePatch(re, p)
+		if err != nil {
+			return json, fmt.Errorf("merge patch failed: %s", err)
+		}
+	case types.StrategicMergePatchType:
+		versionedObject, err := scheme.Scheme.New(gvk)
+		if err != nil {
+			// if getPatch returns this patchType it already handled all error cases
+			return json, fmt.Errorf("unexpected error creating versionedObject: %s", err)
+		}
+
+		out, err = strategicpatch.StrategicMergePatch(re, p, versionedObject)
+		if err != nil {
+			return json, fmt.Errorf("strategic merge patch failed: %s", err)
+		}
+	}
+
+	json = string(out)
+
+	return json, nil
 }

--- a/kustomize/test_kustomizations/_example_app/deployment.yaml
+++ b/kustomize/test_kustomizations/_example_app/deployment.yaml
@@ -1,7 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     app: test
   name: test
@@ -13,7 +12,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: test
     spec:

--- a/kustomize/test_kustomizations/_example_app/ingress.yaml
+++ b/kustomize/test_kustomizations/_example_app/ingress.yaml
@@ -9,6 +9,7 @@ spec:
   - http:
       paths:
       - path: /testpath
+        pathType: ImplementationSpecific
         backend:
           serviceName: test
           servicePort: 80

--- a/kustomize/test_kustomizations/_example_app/service.yaml
+++ b/kustomize/test_kustomizations/_example_app/service.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
     app: test
   name: test

--- a/kustomize/test_kustomizations/basic/modified/deployment2.yaml
+++ b/kustomize/test_kustomizations/basic/modified/deployment2.yaml
@@ -1,7 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     app: test2
   name: test2
@@ -14,7 +13,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: test2
     spec:

--- a/kustomize/test_kustomizations/upgrade_api_version/initial/ingress.yaml
+++ b/kustomize/test_kustomizations/upgrade_api_version/initial/ingress.yaml
@@ -14,6 +14,7 @@ spec:
           serviceName: test-upgrade-api-version
           servicePort: 80
         path: /
+        pathType: ImplementationSpecific
   tls:
   - hosts:
     - test-upgrade-api-version.example.com

--- a/test.tf
+++ b/test.tf
@@ -10,26 +10,42 @@ terraform {
   required_version = ">= 0.13"
 }
 
-data "kustomization_build" "test" {
-  path = "kustomize/test_kustomizations/basic/initial"
+module "test_nginx_ingress" {
+  source  = "kbst.xyz/catalog/nginx/kustomization"
+  version = "0.49.2-kbst.0"
+
+  configuration_base_key = "default"
+  configuration = {
+    default = {}
+  }
 }
 
-resource "kustomization_resource" "from_build" {
-  for_each = data.kustomization_build.test.ids
+module "test_cert_manager" {
+  source  = "kbst.xyz/catalog/cert-manager/kustomization"
+  version = "1.5.4-kbst.0"
 
-  manifest = data.kustomization_build.test.manifests[each.value]
+  configuration_base_key = "default"
+  configuration = {
+    default = {}
+  }
 }
 
-data "kustomization_overlay" "test" {
-  namespace = "test-overlay"
+module "test_prometheus" {
+  source  = "kbst.xyz/catalog/prometheus/kustomization"
+  version = "0.51.1-kbst.0"
 
-  resources = [
-    "kustomize/test_kustomizations/basic/initial"
-  ]
+  configuration_base_key = "default"
+  configuration = {
+    default = {}
+  }
 }
 
-resource "kustomization_resource" "from_overlay" {
-  for_each = data.kustomization_overlay.test.ids
+module "test_tekton" {
+  source  = "kbst.xyz/catalog/tektoncd/kustomization"
+  version = "0.28.1-kbst.0"
 
-  manifest = data.kustomization_overlay.test.manifests[each.value]
+  configuration_base_key = "default"
+  configuration = {
+    default = {}
+  }
 }


### PR DESCRIPTION
Currently, the provider relies on the lastAppliedConfig
annotation. The read method reads the annotation and stores
its value as the manifest in the Terraform state. This means,
Terraform only detects drift for Kubernetes resources managed
by the Kustomization provider, if there is a diff between
what's in the lastAppliedConfig annotation and what's in the
Terraform files.

Not all `kubectl` commands however update the annotation,
e.g. scale doesn't, so such drift is never corrected, even
if replicas was specified in the Terraform files.

Additionally, there are a number of issues (e.g. #136) that
although I have a hard time reproducing them reliably, I
strongly suspect to be a result of the current implementation
here too.

This change, stop relying on the annotation and instead uses
similar but reverse patching logic to the diff and upate
method to determine which attributes of the configuration in
the Terraform files / from YAML are different on the API
server. This is then stored in the state. And now drift is
determined between the values of all attributes set in
TF/YAML and what the API last returned for them.