### PR TITLE
Fix CRD tests

### DIFF
--- a/kustomize/test_kustomizations/crd/initial/co.yaml
+++ b/kustomize/test_kustomizations/crd/initial/co.yaml
@@ -3,10 +3,12 @@ kind: Namespacedcrd
 metadata:
   name: namespacedco
   namespace: test-crd
-spec: {}
+spec:
+  test-key: test-value-initial
 ---
 apiVersion: test.example.com/v1alpha1
 kind: Clusteredcrd
 metadata:
   name: clusteredco
-spec: {}
+spec:
+  test-key: test-value-initial

--- a/kustomize/test_kustomizations/crd/initial/crd.yaml
+++ b/kustomize/test_kustomizations/crd/initial/crd.yaml
@@ -20,7 +20,9 @@ spec:
         properties:
           spec:
             type: object
-            properties: {}
+            properties:
+              test-key:
+                type: string
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -44,4 +46,6 @@ spec:
         properties:
           spec:
             type: object
-            properties: {}
+            properties:
+              test-key:
+                type: string

--- a/kustomize/test_kustomizations/crd/modified/co-patch.yaml
+++ b/kustomize/test_kustomizations/crd/modified/co-patch.yaml
@@ -4,11 +4,11 @@ metadata:
   name: namespacedco
   namespace: test-crd
 spec:
-  test-key: test-value
+  test-key: test-value-modified
 ---
 apiVersion: test.example.com/v1alpha1
 kind: Clusteredcrd
 metadata:
   name: clusteredco
 spec:
-  test-key: test-value
+  test-key: test-value-modified


### PR DESCRIPTION
The CRD tests have always added the test-key attribute. But this
attribute was not set in the CRD's spec. And hence, the test-key
attribute has never been persisted by the K8s API.

Because the provider only stores the last config it applied
in the Terraform state, and only diffs against that, this bug
never caused the tests to fail.