### PR TITLE
Add Kubernetes Provider compatibility layer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
       env:
         KUBECONFIG_PATH: ~/.kube/config
       run: make test
-    
+
     - name: 'Run TF unit tests (${{ matrix.runner }})'
       if: startsWith(matrix.runner, 'ubuntu-') == false
       env:
@@ -161,6 +161,54 @@ jobs:
 
     - name: 'Terraform Apply'
       run: terraform apply --auto-approve
+
+  int_test_kubernetes_provider_compat:
+    runs-on: ubuntu-latest
+    needs: [compile_provider]
+
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v1
+
+      - name: 'Setup Kind'
+        uses: engineerd/setup-kind@v0.5.0
+        with:
+          version: "v0.9.0"
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1.2.1
+        with:
+          terraform_wrapper: false
+          terraform_version: "${{ env.TERRAFORM_VERSION }}"
+
+      - name: 'Download terraform-plugins'
+        uses: actions/download-artifact@v2
+        with:
+          name: terraform-plugins
+          path: terraform.d/plugins
+
+      - name: 'Ensure provider is executable'
+        run: chmod +x terraform.d/plugins/registry.terraform.io/kbst/kustomization/1.0.0/linux_amd64/terraform-provider-kustomization_v1.0.0
+
+      - name: 'Create provider.tf with kubernetes_provider_compat'
+        env:
+          KUBECONFIG_PATH: ~/.kube/config
+        run: |
+          echo > provider.tf <<<EOF
+            provider "kustomization" {
+              kubernetes_provider_compat {
+                host = "$(kubectl config view -o jsonpath="{.clusters[?(@.name==\"kind-kind\")].cluster.server}")"
+                cluster_ca_certificate = "$(kubectl config view --raw -o jsonpath="{.clusters[?(@.name==\"kind-kind\")].cluster.certificate-authority-data}" | base64 --decode)"
+                token = "$(kubectl get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='default')].data.token}" | base64 --decode)"
+              }
+            }
+          EOF
+
+      - name: 'Terraform Init'
+        run: terraform init
+
+      - name: 'Terraform Apply'
+        run: terraform apply --auto-approve
 
   int_test_in_cluster:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR aims to add support to a configuration similar to the [official kubernetes provider](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs) for terraform allowing a configuration similar to ([this](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/examples/irsa/main.tf#L68))
```hcl
provider "kubernetes" {
  host                   = data.aws_eks_cluster.cluster.endpoint
  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
  token                  = data.aws_eks_cluster_auth.cluster.token
}
```

## Background
While referencing the Kubeconfig of e.g. the https://github.com/terraform-aws-modules/terraform-aws-eks works, it only works on a local machine and requires some hacks to get it working on terraform cloud (as the `aws-iam-authenticator` is not available there); It also allows easy integration with GCP using the [same options](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/using_gke_with_terraform#using-the-kubernetes-and-helm-providers).


last but not least: great plugin! 👍🏻 