### PR TITLE
Allow HCL construction of helmCharts kustomize directive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ terraform.d
 *.tfstate*
 crash.log
 dist/
+kustomize/test_kustomizations/helm/remote/

--- a/docs/data-sources/overlay.md
+++ b/docs/data-sources/overlay.md
@@ -585,6 +585,46 @@ data "kustomization_overlay" "minecraft" {
 }
 ```
 
+### `helm_globals` - (optional)
+
+Define [Kustomize helmGlobals](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/chart.md) in support of [helm_charts](#helm_charts)
+
+Must enable helm support via [kustomize_options](#kustomize_options) `enable_helm`
+
+#### Child attributes
+
+- `chart_home` directory to inflate remote helm charts or specify local chart base directory
+- `config_home` directory created by kustomize for the benefit of helm. kustomize sets `HELM_CACHE_HOME={config_home}/.cache` and `HELM_DATA_HOME={config_home}/.data`
+
+#### Example
+
+```hcl
+data "kustomization_overlay" "minecraft" {
+  helm_globals {
+    chart_home = "/local/chart/path/"
+  }
+
+  helm_charts {
+    # this is relative to `chart_home` (eg: ${chart_home}/charts/${name})
+    name = "minecraft"
+    version = "3.1.3"
+    release_name = "moria"
+    values_inline = <<VALUES
+      minecraftServer:
+        eula: true
+        difficulty: hard
+        rcon:
+          enabled: true
+    VALUES
+  }
+
+  kustomize_options = {
+    enable_helm = true
+    helm_path = "helm"
+  }
+}
+```
+
 ## Attribute Reference
 
 - `ids` - Set of Kustomize resource IDs.

--- a/docs/data-sources/overlay.md
+++ b/docs/data-sources/overlay.md
@@ -545,7 +545,7 @@ data "kustomization_overlay" "example" {
 
 Define [Kustomize helmCharts](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/chart.md)
 
-Must enable helm support via [kustomize_options](#kustomize_options) `enable_helm`
+Must enable helm support via [kustomize_options](#kustomize_options---optional) `enable_helm`
 
 #### Child attributes
 
@@ -587,9 +587,9 @@ data "kustomization_overlay" "minecraft" {
 
 ### `helm_globals` - (optional)
 
-Define [Kustomize helmGlobals](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/chart.md) in support of [helm_charts](#helm_charts)
+Define [Kustomize helmGlobals](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/chart.md) in support of [helm_charts](#helm_charts---optional)
 
-Must enable helm support via [kustomize_options](#kustomize_options) `enable_helm`
+Must enable helm support via [kustomize_options](#kustomize_options---optional) `enable_helm`
 
 #### Child attributes
 

--- a/docs/data-sources/overlay.md
+++ b/docs/data-sources/overlay.md
@@ -269,6 +269,8 @@ data "kustomization_overlay" "example" {
 #### Child attributes
 
 - `load_restrictor` - setting this to `"none"` disables load restrictions
+- `enable_helm` - setting this to `true` allows referencing helm charts in the kustomization.yaml
+- `helm_path` - set this to the path of the `helm` binary (defaults to: `helmV3`)
 
 #### Example
 
@@ -276,6 +278,8 @@ data "kustomization_overlay" "example" {
 data "kustomization_overlay" "example" {
   kustomize_options = {
     load_restrictor = "none"
+    enable_helm = true
+    helm_path = "/path/to/helm"
   }
 }
 ```
@@ -533,6 +537,50 @@ data "kustomization_overlay" "example" {
       kind = "Deployment"
       name = "example"
     }
+  }
+}
+```
+
+### `helm_charts` - (optional)
+
+Define [Kustomize helmCharts](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/chart.md)
+
+Must enable helm support via [kustomize_options](#kustomize_options) `enable_helm`
+
+#### Child attributes
+
+- `name` helm chart name
+- `version` helm chart version
+- `repo` helm chart repo to find the chart
+- `release_name` helm chart release name
+- `namespace` namespace to supply to helm for templating
+- `include_crds` enable to generate Custom Resource Definitions from a supporting helm chart (default: false)
+- `values_file` specify a file with helm values to use for templating. Not specifying this uses the in-chart values file, if one exists.
+- `values_inline` specify helm values inline from terraform, as a string
+- `values_merge` merge strategy if both `values_file` and `values_inline` are specified. Can be one of `override`, `replace`, `merge`. (default: `override`)
+
+#### Example
+
+```hcl
+data "kustomization_overlay" "minecraft" {
+  helm_charts {
+    name = "minecraft"
+    version = "3.1.3"
+    repo = "https://itzg.github.io/minecraft-server-charts"
+    release_name = "moria"
+    include_crds = false
+    values_inline = <<VALUES
+      minecraftServer:
+        eula: true
+        difficulty: hard
+        rcon:
+          enabled: true
+    VALUES
+  }
+
+  kustomize_options = {
+    enable_helm = true
+    helm_path = "helm"
   }
 }
 ```

--- a/kustomize/data_source_kustomization_overlay.go
+++ b/kustomize/data_source_kustomization_overlay.go
@@ -343,6 +343,10 @@ func dataSourceKustomizationOverlay() *schema.Resource {
 						"values_merge": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ValidateFunc: validation.StringInSlice(
+								[]string{"override", "replace", "merge"},
+								false,
+							),
 						},
 						"values_file": {
 							Type:     schema.TypeString,

--- a/kustomize/data_source_kustomization_overlay.go
+++ b/kustomize/data_source_kustomization_overlay.go
@@ -16,6 +16,14 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
+func getHelmGlobals(hg map[string]interface{}) *types.HelmGlobals {
+	g := &types.HelmGlobals{}
+	g.ChartHome = hg["chart_home"].(string)
+	g.ConfigHome = hg["config_home"].(string)
+
+	return g
+}
+
 func getGeneratorOptionsSchema() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
@@ -284,6 +292,67 @@ func dataSourceKustomizationOverlay() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
+				},
+			},
+			"helm_globals": &schema.Schema{
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"chart_home": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"config_home": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"helm_charts": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"version": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"repo": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"release_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"namespace": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"include_crds": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"values_merge": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"values_file": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"values_inline": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
 				},
 			},
 			"secret_generator": &schema.Schema{
@@ -629,6 +698,44 @@ func getKustomization(d *schema.ResourceData) (k types.Kustomization) {
 		k.Resources = convertListInterfaceToListString(
 			d.Get("resources").([]interface{}),
 		)
+	}
+
+	if d.Get("helm_globals") != nil {
+		hgs := d.Get("helm_globals").([]interface{})
+
+		if len(hgs) == 1 && hgs[0] != nil {
+			hg := hgs[0].(map[string]interface{})
+			k.HelmGlobals = getHelmGlobals(hg)
+		}
+	}
+
+	if d.Get("helm_charts") != nil {
+		hcs := d.Get("helm_charts").([]interface{})
+		for i := range hcs {
+			if hcs[i] == nil {
+				continue
+			}
+
+			hc := hcs[i].(map[string]interface{})
+			hca := types.HelmChart{}
+
+			hca.Name = hc["name"].(string)
+			hca.Version = hc["version"].(string)
+			hca.Repo = hc["repo"].(string)
+			hca.ReleaseName = hc["release_name"].(string)
+			hca.Namespace = hc["namespace"].(string)
+			hca.ValuesFile = hc["values_file"].(string)
+			hca.ValuesMerge = hc["values_merge"].(string)
+			hca.IncludeCRDs = hc["include_crds"].(bool)
+
+			hc_vi := make(map[string]interface{})
+			if err := yaml.Unmarshal([]byte(hc["values_inline"].(string)), &hc_vi); err != nil {
+				fmt.Printf("error: %v", err)
+			}
+			hca.ValuesInline = hc_vi
+
+			k.HelmCharts = append(k.HelmCharts, hca)
+		}
 	}
 
 	if d.Get("secret_generator") != nil {

--- a/kustomize/data_source_kustomization_overlay_test.go
+++ b/kustomize/data_source_kustomization_overlay_test.go
@@ -1105,7 +1105,7 @@ func TestDataSourceKustomizationOverlay_helm_charts_releasename(t *testing.T) {
 				Config: testDataSourceKustomizationOverlayConfig_helm_charts_releasename(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckOutput("service", "{\"apiVersion\":\"v1\",\"kind\":\"Service\",\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"my-release\"},\"name\":\"my-release\"},\"spec\":{\"ports\":[{\"name\":\"http\",\"port\":80,\"protocol\":\"TCP\",\"targetPort\":80}],\"selector\":{\"app\":\"my-release\"},\"type\":\"ClusterIP\"},\"status\":{\"loadBalancer\":{}}}"),
-					resource.TestCheckOutput("deployment", "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"my-release\"},\"name\":\"my-release\"},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"my-release\"}},\"strategy\":{},\"template\":{\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"my-release\"}},\"spec\":{\"containers\":[{\"image\":\"nginx:6.0.10\",\"name\":\"test-basic\",\"resources\":{}}]}}},\"status\":{}}"),
+					resource.TestCheckOutput("deployment", "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"my-release\"},\"name\":\"my-release\"},\"spec\":{\"replicas\":1,\"selector\":{\"matchLabels\":{\"app\":\"my-release\"}},\"strategy\":{},\"template\":{\"metadata\":{\"creationTimestamp\":null,\"labels\":{\"app\":\"my-release\"}},\"spec\":{\"containers\":[{\"image\":\"nginx:6.0.10\",\"name\":\"test-releasename\",\"resources\":{}}]}}},\"status\":{}}"),
 				),
 			},
 		},

--- a/kustomize/test_kustomizations/helm/initial/alt-values.yaml
+++ b/kustomize/test_kustomizations/helm/initial/alt-values.yaml
@@ -1,0 +1,14 @@
+# Alternate values for test-basic
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 2
+
+image:
+  repository: my-nginx
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "6.0.10"
+
+nginx:
+  port: 443
+

--- a/kustomize/test_kustomizations/helm/initial/charts/test-basic/crds/crontabs.yaml
+++ b/kustomize/test_kustomizations/helm/initial/charts/test-basic/crds/crontabs.yaml
@@ -1,0 +1,40 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: crontabs.stable.example.com
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: stable.example.com
+  # list of versions supported by this CustomResourceDefinition
+  versions:
+    - name: v1
+      # Each version can be enabled/disabled by Served flag.
+      served: true
+      # One and only one version must be marked as the storage version.
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                cronSpec:
+                  type: string
+                image:
+                  type: string
+                replicas:
+                  type: integer
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: crontabs
+    # singular name to be used as an alias on the CLI and for display
+    singular: crontab
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: CronTab
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - ct

--- a/kustomize/test_kustomizations/helm/initial/charts/test-releasename/Chart.yaml
+++ b/kustomize/test_kustomizations/helm/initial/charts/test-releasename/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+description: A Simple Helm chart
+name: test-releasename
+version: 0.0.1

--- a/kustomize/test_kustomizations/helm/initial/charts/test-releasename/templates/_helpers.tpl
+++ b/kustomize/test_kustomizations/helm/initial/charts/test-releasename/templates/_helpers.tpl
@@ -1,0 +1,6 @@
+{{/*
+Expand the name of the chart. Set the chart name to nginx by default
+*/}}
+{{- define "test-basic.name" -}}
+{{- .Release.Name | default "nginx" }}
+{{- end }}

--- a/kustomize/test_kustomizations/helm/initial/charts/test-releasename/templates/deployment.yaml
+++ b/kustomize/test_kustomizations/helm/initial/charts/test-releasename/templates/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: {{ include "test-basic.name" . }}
+  name: {{ include "test-basic.name" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "test-basic.name" . }}
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: {{ include "test-basic.name" . }}
+    spec:
+      containers:
+      - image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        name : {{ .Chart.Name }}
+        resources: {}
+status: {}

--- a/kustomize/test_kustomizations/helm/initial/charts/test-releasename/templates/ingress.yaml
+++ b/kustomize/test_kustomizations/helm/initial/charts/test-releasename/templates/ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: {{ include "test-basic.name" . }}
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /testpath
+        backend:
+          serviceName: {{ include "test-basic.name" . }}
+          servicePort: {{ .Values.nginx.port }}
+

--- a/kustomize/test_kustomizations/helm/initial/charts/test-releasename/templates/service.yaml
+++ b/kustomize/test_kustomizations/helm/initial/charts/test-releasename/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: {{ include "test-basic.name" . }}
+  name: {{ include "test-basic.name" . }}
+spec:
+  ports:
+  - name: http
+    port: {{ .Values.nginx.port }}
+    protocol: TCP
+    targetPort: {{ .Values.nginx.port }}
+  selector:
+    app: {{ include "test-basic.name" . }}
+  type: ClusterIP
+status: 
+  loadBalancer: {}

--- a/kustomize/test_kustomizations/helm/initial/charts/test-releasename/values.yaml
+++ b/kustomize/test_kustomizations/helm/initial/charts/test-releasename/values.yaml
@@ -1,0 +1,13 @@
+# Default values for test-basic
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: nginx
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "6.0.10"
+
+nginx:
+  port: 80

--- a/kustomize/test_kustomizations/helm/initial/merge-values.yaml
+++ b/kustomize/test_kustomizations/helm/initial/merge-values.yaml
@@ -1,0 +1,7 @@
+# Alternate values for test-basic
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+image:
+  repository: my-nginx
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "6.0.10"


### PR DESCRIPTION
This allows the use of the `helmCharts` directive in kustomize from HCL, allowing easier templating and variant customization from Terraform, as well as the `helmGlobals` directive.

Previous to this, the `kustomization_overlay` datasource was effectively the same as the `kustomization_build` datasource, as regards helm charts. This fixes that and makes it so things like chart version, release name, inline values, etc can be supplied by terraform in an idiomatic way.
