### PR TITLE
Use KUBECONFIG environment variable to find kubectl configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,17 +42,17 @@ This is a standalone Terraform Provider, but is also used in the [Terraform GitO
 
 ## Getting Help
 
-**Community Help**  
+**Community Help**
 If you have any questions while following the tutorial, join the [#kubestack](https://app.slack.com/client/T09NY5SBT/CMBCT7XRQ) channel on the Kubernetes community. To create an account request an [invitation](https://slack.k8s.io/).
 
-**Professional Services**  
+**Professional Services**
 For organizations interested in accelerating their GitOps journey, [professional services](https://www.kubestack.com/lp/professional-services) are available.
 
 
 ## Contributing
 Contributions to the Kubestack framework are welcome and encouraged. Before contributing, please read the [Contributing](./CONTRIBUTING.md) and [Code of Conduct](./CODE_OF_CONDUCT.md) Guidelines.
 
-One super simple way to contribute to the success of this project is to give it a star.  
+One super simple way to contribute to the success of this project is to give it a star.
 
 <div align="center">
 
@@ -77,7 +77,7 @@ To compile the provider, run `make build` as shown below. This will build the pr
 make build
 ```
 
-In order to test the provider, run the acceptance tests using `make test`. You have to set the `KUBECONFIG_PATH` environment variable to point the tests to a valid config file. Each tests uses an individual namespaces. [Kind](https://github.com/kubernetes-sigs/kind) or [Minikube](https://github.com/kubernetes/minikube) clusters work well for testing.
+In order to test the provider, run the acceptance tests using `make test`. You have to set the `KUBECONFIG_PATH` or `KUBECONFIG` environment variable to point the tests to a valid config file. Each tests uses an individual namespaces. [Kind](https://github.com/kubernetes-sigs/kind) or [Minikube](https://github.com/kubernetes/minikube) clusters work well for testing.
 
 ```sh
 make test
@@ -156,12 +156,11 @@ then run terraform. Instructions here are for Visual Studio Code, configuring ot
 * Click the debug button and choose "Launch test function" in the dropdown
 
 ## Kubestack Repositories
-* [kbst/terraform-kubestack](https://github.com/kbst/terraform-kubestack)  
+* [kbst/terraform-kubestack](https://github.com/kbst/terraform-kubestack)
     * Terraform GitOps Framework - Everything you need to build reliable automation for AKS, EKS and GKE Kubernetes clusters in one free and open-source framework.
-* [kbst/kbst](https://github.com/kbst/kbst)  
+* [kbst/kbst](https://github.com/kbst/kbst)
     * Kubestack Framework CLI - All-in-one CLI to scaffold your Infrastructure as Code repository and deploy your entire platform stack locally for faster iteration.
-* [kbst/terraform-provider-kustomization](https://github.com/kbst/terraform-provider-kustomization) (this repository)  
+* [kbst/terraform-provider-kustomization](https://github.com/kbst/terraform-provider-kustomization) (this repository)
     * Kustomize Terraform Provider - A Kubestack maintained Terraform provider for Kustomize, available in the [Terraform registry](https://registry.terraform.io/providers/kbst/kustomization/latest).
-* [kbst/catalog](https://github.com/kbst/catalog)  
+* [kbst/catalog](https://github.com/kbst/catalog)
     * Catalog of cluster services as Kustomize bases - Continuously tested and updated Kubernetes services, installed and customizable using native Terraform syntax.
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ provider "kustomization" {
   # one of kubeconfig_path, kubeconfig_raw or kubeconfig_incluster must be set
 
   # kubeconfig_path = "~/.kube/config"
-  # can also be set using KUBECONFIG_PATH environment variable
+  # can also be set using KUBECONFIG_PATH or KUBECONFIG environment variable
 
   # kubeconfig_raw = data.template_file.kubeconfig.rendered
   # kubeconfig_raw = yamlencode(local.kubeconfig)
@@ -42,7 +42,7 @@ provider "kustomization" {
 
 ## Argument Reference
 
-- `kubeconfig_path` - Path to a kubeconfig file. Can be set using `KUBECONFIG_PATH` environment variable.
+- `kubeconfig_path` - Path to a kubeconfig file. Can be set using `KUBECONFIG_PATH` or `KUBECONFIG` environment variable.
 - `kubeconfig_raw` - Raw kubeconfig file. If `kubeconfig_raw` is set, `kubeconfig_path` is ignored.
 - `kubeconfig_incluster` - Set to `true` when running inside a kubernetes cluster.
 - `context` - (Optional) Context to use in kubeconfig with multiple contexts, if not specified the default context is used.

--- a/kustomize/provider.go
+++ b/kustomize/provider.go
@@ -48,21 +48,21 @@ func Provider() *schema.Provider {
 			"kubeconfig_path": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				DefaultFunc:  schema.EnvDefaultFunc("KUBECONFIG_PATH", nil),
+				DefaultFunc:  schema.MultiEnvDefaultFunc([]string{"KUBECONFIG_PATH", "KUBECONFIG"}, nil),
 				ExactlyOneOf: []string{"kubeconfig_path", "kubeconfig_raw", "kubeconfig_incluster"},
-				Description:  "Path to a kubeconfig file. Can be set using KUBECONFIG_PATH env var",
+				Description:  "Path to a kubeconfig file. Can be set using KUBECONFIG_PATH or KUBECONFIG env var, with KUBECONFIG_PATH taking priority",
 			},
 			"kubeconfig_raw": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ExactlyOneOf: []string{"kubeconfig_path", "kubeconfig_raw", "kubeconfig_incluster"},
-				Description:  "Raw kube config. If kubeconfig_raw is set, KUBECONFIG_PATH is ignored.",
+				Description:  "Raw kube config. If kubeconfig_raw is set, KUBECONFIG_PATH and KUBECONFIG are ignored.",
 			},
 			"kubeconfig_incluster": {
 				Type:         schema.TypeBool,
 				Optional:     true,
 				ExactlyOneOf: []string{"kubeconfig_path", "kubeconfig_raw", "kubeconfig_incluster"},
-				Description:  "Set to true when running inside a kubernetes cluster. If kubeconfig_incluster is set, KUBECONFIG_PATH is ignored.",
+				Description:  "Set to true when running inside a kubernetes cluster. If kubeconfig_incluster is set, KUBECONFIG_PATH and KUBECONFIG are ignored.",
 			},
 			"context": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
The variable KUBECONFIG is usually used by developers to write their kubectl configs
to a different file based on their projects, it will help developers a lot
if we use this env variable to locate the config file as well as
the old KUBECONFIG_PATH variable for backward compatibility