### PR TITLE
Allow adding labels without also automatically injecting corresponding selectors

### DIFF
--- a/docs/data-sources/overlay.md
+++ b/docs/data-sources/overlay.md
@@ -94,6 +94,29 @@ data "kustomization_overlay" "example" {
 }
 ```
 
+### `labels` - (optional)
+
+Set [Kustomize labels](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/labels/) using `labels` key/value pairs. Sets `labels` without also automatically injecting corresponding selectors.
+
+#### Example
+
+```hcl
+# example shows how keys and values can be references
+locals {
+  label_key   = "example-label"
+  label_value = true
+}
+
+data "kustomization_overlay" "example" {
+  labels {
+    pairs = {
+      (local.label_key) = local.label_value
+    }
+    include_selectors = true # <-- false by default
+  }
+}
+```
+
 ### `components` - (optional)
 
 Add one or more paths to [Kustomize components](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/components/) to inherit from.

--- a/kustomize/data_source_kustomization_overlay.go
+++ b/kustomize/data_source_kustomization_overlay.go
@@ -103,6 +103,23 @@ func dataSourceKustomizationOverlay() *schema.Resource {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"labels": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"pairs": {
+							Type:     schema.TypeMap,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"include_selectors": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+					},
+				},
+			},
 			"components": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
@@ -553,6 +570,24 @@ func getKustomization(d *schema.ResourceData) (k types.Kustomization) {
 		k.CommonLabels = convertMapStringInterfaceToMapStringString(
 			d.Get("common_labels").(map[string]interface{}),
 		)
+	}
+
+	if d.Get("labels") != nil {
+		lbls := d.Get("labels").([]interface{})
+		for i := range lbls {
+			if lbls[i] == nil {
+				continue
+			}
+			lbl := lbls[i].(map[string]interface{})
+			lb := types.Label{}
+
+			lb.Pairs = convertMapStringInterfaceToMapStringString(
+				lbl["pairs"].(map[string]interface{}),
+			)
+			lb.IncludeSelectors = lbl["include_selectors"].(bool)
+
+			k.Labels = append(k.Labels, lb)
+		}
 	}
 
 	if d.Get("components") != nil {

--- a/tests/kubestack-starter-kind/kind_zero_test_module.tf
+++ b/tests/kubestack-starter-kind/kind_zero_test_module.tf
@@ -26,6 +26,12 @@ module "kind_zero_test_module" {
         "test-label" = "test"
       }
 
+      labels = [{
+        pairs = {
+          "test-label-only" = "test"
+        }
+      }]
+
       generator_options = {
         annotations = {
           annotation-generated = "test"


### PR DESCRIPTION
This allow to use `labels` in order to allow adding labels without also automatically injecting corresponding selectors.

Selectors for resources such as Deployments and Services can’t be changed once the resource has been applied to a cluster. The resource needs to be recreated which break the rollout mechanism.

https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/labels/