### PR TITLE
support resource level kubernetes configuration.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -361,6 +361,7 @@ jobs:
     - name: 'Temporarily use old provider version'
       run: |
         mv test-schema-migration._tf test.tf
+        mv test-with-resource-kubeconfig.tf test-with-resource-kubeconfig._tf
 
     - name: 'Terraform Init'
       run: terraform init

--- a/kustomize/client.go
+++ b/kustomize/client.go
@@ -1,0 +1,111 @@
+package kustomize
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/mitchellh/go-homedir"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/client-go/tools/clientcmd"
+
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+)
+
+// KubeClient holds kubernetes configuration
+type KubeClient struct {
+	Client dynamic.Interface
+	Mapper *restmapper.DeferredDiscoveryRESTMapper
+}
+
+func initializeClient(raw, path, kubecontext string, incluster bool) (*KubeClient, error) {
+	var config *rest.Config
+	var err error
+
+	if raw != "" {
+		config, err = getClientConfig([]byte(raw), kubecontext)
+		if err != nil {
+			return nil, fmt.Errorf("provider kustomization: kubeconfig_raw: %s", err)
+		}
+	}
+
+	if raw == "" && path != "" {
+		data, err := readKubeconfigFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("provider kustomization: kubeconfig_path: %s", err)
+		}
+
+		config, err = getClientConfig(data, kubecontext)
+		if err != nil {
+			return nil, fmt.Errorf("provider kustomization: kubeconfig_path: %s", err)
+		}
+	}
+
+	if incluster {
+		config, err = rest.InClusterConfig()
+		if err != nil {
+			return nil, fmt.Errorf("provider kustomization: couldn't load in cluster config: %s", err)
+		}
+	}
+
+	// empty default config required to support
+	// using a cluster resource or data source
+	// that may not exist yet, to configure the provider
+	if config == nil {
+		config = &rest.Config{}
+	}
+
+	// Increase QPS and Burst rate limits
+	config.QPS = 120
+	config.Burst = 240
+
+	client, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("provider kustomization: %s", err)
+	}
+
+	dc, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("provider kustomization: %s", err)
+	}
+
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(dc))
+
+	return &KubeClient{client, mapper}, nil
+}
+
+func readKubeconfigFile(s string) ([]byte, error) {
+	p, err := homedir.Expand(s)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := ioutil.ReadFile(p)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func getClientConfig(data []byte, context string) (*rest.Config, error) {
+	if len(context) == 0 {
+		return clientcmd.RESTConfigFromKubeConfig(data)
+	}
+
+	rawConfig, err := clientcmd.Load(data)
+	if err != nil {
+		return nil, err
+	}
+
+	var clientConfig clientcmd.ClientConfig = clientcmd.NewNonInteractiveClientConfig(
+		*rawConfig,
+		context,
+		&clientcmd.ConfigOverrides{CurrentContext: context},
+		nil)
+
+	return clientConfig.ClientConfig()
+}

--- a/kustomize/provider.go
+++ b/kustomize/provider.go
@@ -2,29 +2,18 @@ package kustomize
 
 import (
 	"fmt"
-	"io/ioutil"
 	"sync"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
-	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/discovery/cached/memory"
-	"k8s.io/client-go/dynamic"
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/restmapper"
-	"k8s.io/client-go/tools/clientcmd"
-
-	"github.com/mitchellh/go-homedir"
 )
 
 // Config ...
 type Config struct {
-	Client dynamic.Interface
-	Mapper *restmapper.DeferredDiscoveryRESTMapper
-	Mutex  *sync.Mutex
+	KubeClient
+
+	Mutex *sync.Mutex
 	// whether legacy IDs are produced or not
-	LegacyIDs bool
+	LegacyIDs             bool
 	GzipLastAppliedConfig bool
 }
 
@@ -88,106 +77,23 @@ func Provider() *schema.Provider {
 	}
 
 	p.ConfigureFunc = func(d *schema.ResourceData) (interface{}, error) {
-		var config *rest.Config
-		var err error
-
-		raw := d.Get("kubeconfig_raw").(string)
-		path := d.Get("kubeconfig_path").(string)
+		kubeconfigRaw := d.Get("kubeconfig_raw").(string)
+		kubeconfigPath := d.Get("kubeconfig_path").(string)
 		incluster := d.Get("kubeconfig_incluster").(bool)
-		context := d.Get("context").(string)
+		kubeContext := d.Get("context").(string)
 
-		if raw != "" {
-			config, err = getClientConfig([]byte(raw), context)
-			if err != nil {
-				return nil, fmt.Errorf("provider kustomization: kubeconfig_raw: %s", err)
-			}
-		}
+		k, err := initializeClient(kubeconfigRaw, kubeconfigPath, kubeContext, incluster)
 
-		if raw == "" && path != "" {
-			data, err := readKubeconfigFile(path)
-			if err != nil {
-				return nil, fmt.Errorf("provider kustomization: kubeconfig_path: %s", err)
-			}
-
-			config, err = getClientConfig(data, context)
-			if err != nil {
-				return nil, fmt.Errorf("provider kustomization: kubeconfig_path: %s", err)
-			}
-		}
-
-		if incluster {
-			config, err = rest.InClusterConfig()
-			if err != nil {
-				return nil, fmt.Errorf("provider kustomization: couldn't load in cluster config: %s", err)
-			}
-		}
-
-		// empty default config required to support
-		// using a cluster resource or data source
-		// that may not exist yet, to configure the provider
-		if config == nil {
-			config = &rest.Config{}
-		}
-
-		// Increase QPS and Burst rate limits
-		config.QPS = 120
-		config.Burst = 240
-
-		client, err := dynamic.NewForConfig(config)
-		if err != nil {
+		if k == nil || err != nil {
 			return nil, fmt.Errorf("provider kustomization: %s", err)
 		}
-
-		dc, err := discovery.NewDiscoveryClientForConfig(config)
-		if err != nil {
-			return nil, fmt.Errorf("provider kustomization: %s", err)
-		}
-
-		mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(dc))
-
-		// Mutex to prevent parallel Kustomizer runs
-		// temp workaround for upstream bug
-		// https://github.com/kubernetes-sigs/kustomize/issues/3659
 		mu := &sync.Mutex{}
 
 		legacyIDs := d.Get("legacy_id_format").(bool)
 		gzipLastAppliedConfig := d.Get("gzip_last_applied_config").(bool)
 
-		return &Config{client, mapper, mu, legacyIDs, gzipLastAppliedConfig}, nil
+		return &Config{*k, mu, legacyIDs, gzipLastAppliedConfig}, nil
 	}
 
 	return p
-}
-
-func readKubeconfigFile(s string) ([]byte, error) {
-	p, err := homedir.Expand(s)
-	if err != nil {
-		return nil, err
-	}
-
-	data, err := ioutil.ReadFile(p)
-	if err != nil {
-		return nil, err
-	}
-
-	return data, nil
-}
-
-func getClientConfig(data []byte, context string) (*rest.Config, error) {
-	if len(context) == 0 {
-		return clientcmd.RESTConfigFromKubeConfig(data)
-	}
-
-	rawConfig, err := clientcmd.Load(data)
-	if err != nil {
-		return nil, err
-	}
-
-	var clientConfig clientcmd.ClientConfig = clientcmd.NewNonInteractiveClientConfig(
-		*rawConfig,
-		context,
-		&clientcmd.ConfigOverrides{CurrentContext: context},
-		nil)
-
-	return clientConfig.ClientConfig()
 }

--- a/kustomize/test_kustomizations/basic_for_resource_config/initial/kustomization.yaml
+++ b/kustomize/test_kustomizations/basic_for_resource_config/initial/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: test-basic-for-resource-config
+
+resources:
+- namespace.yaml
+- ../../_example_app

--- a/kustomize/test_kustomizations/basic_for_resource_config/initial/namespace.yaml
+++ b/kustomize/test_kustomizations/basic_for_resource_config/initial/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-basic-for-resource-config

--- a/kustomize/test_kustomizations/basic_for_resource_config/modified/deployment2.yaml
+++ b/kustomize/test_kustomizations/basic_for_resource_config/modified/deployment2.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: test2
+  name: test2
+  namespace: test-basic-for-resource-config
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test2
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: test2
+    spec:
+      containers:
+      - image: nginx
+        name: nginx
+        resources: {}
+status: {}

--- a/kustomize/test_kustomizations/basic_for_resource_config/modified/kustomization.yaml
+++ b/kustomize/test_kustomizations/basic_for_resource_config/modified/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../initial
+- deployment2.yaml

--- a/kustomize/util.go
+++ b/kustomize/util.go
@@ -43,15 +43,15 @@ func setLastAppliedConfig(u *k8sunstructured.Unstructured, srcJSON string, gzipL
 		if sErr != nil {
 			needsGzip = true
 		}
-	
+
 		if needsGzip {
 			var buf bytes.Buffer
 			zw := gzip.NewWriter(&buf)
-	
+
 			_, err1 := zw.Write([]byte(srcJSON))
-	
+
 			err2 := zw.Close()
-	
+
 			if err1 == nil && err2 == nil {
 				annotations[gzipLastAppliedConfigAnnotation] = base64.StdEncoding.EncodeToString(buf.Bytes())
 				delete(annotations, lastAppliedConfigAnnotation)
@@ -74,17 +74,17 @@ func getLastAppliedConfig(u *k8sunstructured.Unstructured, gzipLastAppliedConfig
 			if err != nil {
 				log.Fatal(err)
 			}
-	
+
 			var buf bytes.Buffer
 			buf.Write(gzDec)
-	
+
 			zr, err1 := gzip.NewReader(&buf)
-	
+
 			lacBuf := new(strings.Builder)
 			_, err2 := io.Copy(lacBuf, zr)
-	
+
 			err3 := zr.Close()
-	
+
 			// in case of any error, fall back to the uncompressed lac
 			if err1 == nil && err2 == nil && err3 == nil {
 				lac = lacBuf.String()
@@ -95,9 +95,9 @@ func getLastAppliedConfig(u *k8sunstructured.Unstructured, gzipLastAppliedConfig
 	return strings.TrimRight(lac, "\r\n")
 }
 
-func getOriginalModifiedCurrent(originalJSON string, modifiedJSON string, currentAllowNotFound bool, m interface{}) (original []byte, modified []byte, current []byte, err error) {
-	client := m.(*Config).Client
-	mapper := m.(*Config).Mapper
+func getOriginalModifiedCurrent(k *KubeClient, originalJSON string, modifiedJSON string, currentAllowNotFound bool, m interface{}) (original []byte, modified []byte, current []byte, err error) {
+	client := k.Client
+	mapper := k.Mapper
 	gzipLastAppliedConfig := m.(*Config).GzipLastAppliedConfig
 
 	n, err := parseJSON(modifiedJSON)

--- a/test-with-resource-kubeconfig.tf
+++ b/test-with-resource-kubeconfig.tf
@@ -1,0 +1,10 @@
+data "kustomization_build" "test_for_resource_config" {
+  path = "kustomize/test_kustomizations/basic_for_resource_config/initial"
+}
+
+resource "kustomization_resource" "from_build_for_resource_config" {
+  for_each = data.kustomization_build.test_for_resource_config.ids
+
+  manifest        = data.kustomization_build.test_for_resource_config.manifests[each.value]
+  kubeconfig_path = "~/.kube/config"
+}


### PR DESCRIPTION
This patch introduces support for providing kubernetes configuration at the
resource level as below:

```hcl
resource "kustomization_resource" "from_overlay" {
  for_each = data.kustomization_overlay.test.ids

  manifest        = data.kustomization_overlay.test.manifests[each.value]
  kubeconfig_path = "~/.kube/config"
}
```

or:

```hcl
resource "kustomization_resource" "from_overlay" {
  for_each = data.kustomization_overlay.test.ids

  manifest        = data.kustomization_overlay.test.manifests[each.value]
  kubeconfig_raw  = <<EOF
replace_with_kube_config_content
EOF
}
```

## Why is this needed

### case 1

When the provider is initialized with a kubeconfig dynamically e.g from
another module as below:

```hcl
module "kubernetes_cluster" {
  source = "some_module_name"
  # some variables here, but the module outputs a `kubeconfig`
}

provider "kustomization" {
  kubeconfig_raw = module.kubernetes_cluster.kubeconfig
}
```

in some situations terraform will initialize the provider before the modules
output is available and set `kubeconfig_raw` as an empty string. See
https://github.com/hashicorp/terraform/issues/2430#:~:text=commented-,on%20Feb%2028,-%E2%80%A2
for more details on this. When the provider receives an empty string as its
configuration the kubernetes client-go falls back to its default client
initialization and fails with:

```
Error: Get "http://localhost/api?timeout=32s": dial tcp [::1]:80: connect: connection refused
```

With this patch, the resource dependency is explicit, and terraform will not
proceed with calling the client until the module providing the dynamic
kubeconfig is completely resolved.

### case 2

When this provider and its resources are embedded in a module, it is not
possible to use the module in a `for_each` loop to target different clusters.
Take the previous example in case one with variables `kubeconfig` and
`cluster_name`, if one attempts to use it in a for_each loop as below:

```hcl

locals = {
  clusters = {
    "one": "kube_config_for_cluster_one",
    "two": "kubeconfig_for_cluster_2",
  }
}

module "wrapping_cluster_and_kustomization" {
  for_each = local.clusters

  kubeconfig = each.value
  cluster_name = each.key
}
```

The above fails with the below error:

```
The module at module.wrapping_cluster_and_kustomization is a legacy module which contains its own local provider configurations, and so calls to it may not use the count, for_each, or depends_on arguments.
```

Moving the kubeconfig into the resource definition means we can have a root
provider with `kubeconfig_raw` configured to an empty string while the module
sets the `kubeconfig` passed into it to the resources and can do without the
provider configuration.

## drawbacks

Each resource definition will trigger at least 2 API calls to the apiserver,
one for Read and the other for Exists, unlike provider level configuration
that reuses the same TCP connection.