### PR TITLE
Add server side dry-run before create fix #24

### DIFF
--- a/kustomize/resource_kustomization_test.go
+++ b/kustomize/resource_kustomization_test.go
@@ -606,6 +606,33 @@ resource "kustomization_resource" "ns" {
 
 //
 //
+// Fail plan invalid manifest
+func TestAccResourceKustomization_failPlanInvalid(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			//
+			//
+			// Expect plan to fail due to invalid roleRef
+			{
+				Config:      testAccResourceKustomizationConfig_failPlanInvalid("test_kustomizations/fail_plan_invalid"),
+				ExpectError: regexp.MustCompile("Error: github.com/kbst/terraform-provider-kustomize/kustomize.kustomizationResourceDiff \"rbac.authorization.k8s.io/ClusterRoleBinding/_/invalid\": ClusterRoleBinding.rbac.authorization.k8s.io \"invalid\" is invalid: roleRef.kind: Unsupported value: \"Role\": supported values: \"ClusterRole\""),
+			},
+		},
+	})
+}
+
+func testAccResourceKustomizationConfig_failPlanInvalid(path string) string {
+	return testAccDataSourceKustomizationConfig_basic(path) + `
+resource "kustomization_resource" "crb" {
+	manifest = data.kustomization_build.test.manifests["rbac.authorization.k8s.io/ClusterRoleBinding/_/invalid"]
+}
+`
+}
+
+//
+//
 // Webhook Test
 func TestAccResourceKustomization_webhook(t *testing.T) {
 

--- a/kustomize/test_kustomizations/fail_plan_invalid/invalid_cluster_role_binding.yaml
+++ b/kustomize/test_kustomizations/fail_plan_invalid/invalid_cluster_role_binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: invalid
+subjects:
+- kind: Group
+  name: admins
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  # invalid roleRef to fail test
+  kind: Role
+  name: secret-reader
+  namespace: default
+  apiGroup: rbac.authorization.k8s.io

--- a/kustomize/test_kustomizations/fail_plan_invalid/kustomization.yaml
+++ b/kustomize/test_kustomizations/fail_plan_invalid/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- invalid_cluster_role_binding.yaml


### PR DESCRIPTION
 * requires namespace to exist for namespaced resources
 * requires CRD to exist for custom objects

If namespace or CRD does not exist, the server side dry-run
result is ignored for the respective resource.