### PR TITLE
Error when namespace set but not allowed or not set when required

### DIFF
--- a/kustomize/resource_kustomization_test.go
+++ b/kustomize/resource_kustomization_test.go
@@ -606,6 +606,60 @@ resource "kustomization_resource" "ns" {
 
 //
 //
+// Fail namespace not allowed
+func TestAccResourceKustomization_failPlanInvalidNamespaceNotAllowed(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			//
+			//
+			// Expect plan to fail due to namespace not allowed
+			{
+				Config:      testAccResourceKustomizationConfig_failNamespaceNotAllowed("test_kustomizations/fail_namespace_not_allowed"),
+				ExpectError: regexp.MustCompile("Error: github.com/kbst/terraform-provider-kustomize/kustomize.kustomizationResourceDiff: \"rbac.authorization.k8s.io/ClusterRoleBinding/default/invalid\": is not namespace scoped but has metadata.namespace set"),
+			},
+		},
+	})
+}
+
+func testAccResourceKustomizationConfig_failNamespaceNotAllowed(path string) string {
+	return testAccDataSourceKustomizationConfig_basic(path) + `
+resource "kustomization_resource" "crb" {
+	manifest = data.kustomization_build.test.manifests["rbac.authorization.k8s.io/ClusterRoleBinding/default/invalid"]
+}
+`
+}
+
+//
+//
+// Fail namespace required
+func TestAccResourceKustomization_failNamespaceRequired(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			//
+			//
+			// Expect plan to fail due to missing namespace
+			{
+				Config:      testAccResourceKustomizationConfig_failNamespaceRequired("test_kustomizations/fail_namespace_required"),
+				ExpectError: regexp.MustCompile("Error: github.com/kbst/terraform-provider-kustomize/kustomize.kustomizationResourceDiff: \"rbac.authorization.k8s.io/RoleBinding/_/invalid\": is namespace scoped and must set metadata.namespace"),
+			},
+		},
+	})
+}
+
+func testAccResourceKustomizationConfig_failNamespaceRequired(path string) string {
+	return testAccDataSourceKustomizationConfig_basic(path) + `
+resource "kustomization_resource" "crb" {
+	manifest = data.kustomization_build.test.manifests["rbac.authorization.k8s.io/RoleBinding/_/invalid"]
+}
+`
+}
+
+//
+//
 // Fail plan invalid manifest
 func TestAccResourceKustomization_failPlanInvalid(t *testing.T) {
 

--- a/kustomize/test_kustomizations/fail_namespace_not_allowed/invalid_cluster_role_binding.yaml
+++ b/kustomize/test_kustomizations/fail_namespace_not_allowed/invalid_cluster_role_binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: invalid
+  # invalid not namespace scoped
+  namespace: default
+subjects:
+- kind: Group
+  name: admins
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/kustomize/test_kustomizations/fail_namespace_not_allowed/kustomization.yaml
+++ b/kustomize/test_kustomizations/fail_namespace_not_allowed/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- invalid_cluster_role_binding.yaml

--- a/kustomize/test_kustomizations/fail_namespace_required/invalid_role_binding.yaml
+++ b/kustomize/test_kustomizations/fail_namespace_required/invalid_role_binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: invalid
+  # invalid namespace scoped but no namespace
+subjects:
+- kind: Group
+  name: admins
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/kustomize/test_kustomizations/fail_namespace_required/kustomization.yaml
+++ b/kustomize/test_kustomizations/fail_namespace_required/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- invalid_role_binding.yaml


### PR DESCRIPTION
Previously the provider would just error with not found,
which frequently confused users not closely paying attention
if their resource is namespace scoped or not.