### PR TITLE
Add wait functionality for deployments and daemonsets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       if: startsWith(matrix.runner, 'ubuntu-')
       uses: engineerd/setup-kind@v0.5.0
       with:
-        version: "v0.9.0"
+        version: "v0.17.0"
 
     - name: Set up Go
       uses: actions/setup-go@v2

--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -68,6 +68,7 @@ resource "kustomization_resource" "p0" {
 
 # then loop through resources in ids_prio[1]
 # and set an explicit depends_on on kustomization_resource.p0
+# wait 2 minutes for any deployment or daemonset to become ready
 resource "kustomization_resource" "p1" {
   for_each = data.kustomization_build.test.ids_prio[1]
 
@@ -76,6 +77,11 @@ resource "kustomization_resource" "p1" {
     ? sensitive(data.kustomization_build.test.manifests[each.value])
     : data.kustomization_build.test.manifests[each.value]
   )
+  wait = true
+  timeouts {
+    create = "2m"
+    update = "2m"
+  }
 
   depends_on = [kustomization_resource.p0]
 }
@@ -99,4 +105,5 @@ resource "kustomization_resource" "p2" {
 ## Argument Reference
 
 - `manifest` - (Required) JSON encoded Kubernetes resource manifest.
-- 'timeouts' - (Optional) Overwrite `create` or `delete` timeout defaults. Defaults are 5 minutes for `create` and 10 minutes for `delete`.
+- `wait` - Whether to wait for pods to become ready (default false). Currently only has an effect for Deployments and DaemonSets.
+- 'timeouts' - (Optional) Overwrite `create`, `update` or `delete` timeout defaults. Defaults are 5 minutes for `create` and `update` and 10 minutes for `delete`.

--- a/kustomize/manifest.go
+++ b/kustomize/manifest.go
@@ -432,10 +432,13 @@ func waitDeploymentRefresh(km *kManifest) (interface{}, string, error) {
 func (km *kManifest) waitCreatedOrUpdated(t time.Duration) error {
 	gvk := km.gvk()
 	if refresh, ok := waitRefreshFunctions[fmt.Sprintf("%s/%s", gvk.Group, gvk.Kind)]; ok {
+		delay := 10 * time.Second
 		stateConf := &resource.StateChangeConf{
-			Target:  []string{"done"},
-			Pending: []string{"in progress"},
-			Timeout: t,
+			Target:         []string{"done"},
+			Pending:        []string{"in progress"},
+			Timeout:        t,
+			Delay:          delay,
+			NotFoundChecks: int(t/delay) + 1,
 			Refresh: func() (interface{}, string, error) {
 				return refresh(km)
 			},

--- a/kustomize/manifest.go
+++ b/kustomize/manifest.go
@@ -438,7 +438,7 @@ func (km *kManifest) waitCreatedOrUpdated(t time.Duration) error {
 			Pending:        []string{"in progress"},
 			Timeout:        t,
 			Delay:          delay,
-			NotFoundChecks: int(t/delay) + 1,
+			NotFoundChecks: 2*int(t/delay) + 1,
 			Refresh: func() (interface{}, string, error) {
 				return refresh(km)
 			},

--- a/kustomize/resource_kustomization.go
+++ b/kustomize/resource_kustomization.go
@@ -35,10 +35,16 @@ func kustomizationResource() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"wait": &schema.Schema{
+				Type:     schema.TypeBool,
+				Default:  false,
+				Optional: true,
+			},
 		},
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 	}
@@ -101,6 +107,12 @@ func kustomizationResourceCreate(d *schema.ResourceData, m interface{}) error {
 	resp, err := km.apiCreate(k8smetav1.CreateOptions{})
 	if err != nil {
 		return logError(err)
+	}
+
+	if d.Get("wait").(bool) {
+		if err = km.waitCreatedOrUpdated(d.Timeout(schema.TimeoutCreate)); err != nil {
+			return logError(err)
+		}
 	}
 
 	id := string(resp.GetUID())
@@ -325,6 +337,12 @@ func kustomizationResourceUpdate(d *schema.ResourceData, m interface{}) error {
 	resp, err := kmm.apiPatch(pt, p, k8smetav1.PatchOptions{})
 	if err != nil {
 		return logError(err)
+	}
+
+	if d.Get("wait").(bool) {
+		if err = kmm.waitCreatedOrUpdated(d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return logError(err)
+		}
 	}
 
 	id := string(resp.GetUID())

--- a/kustomize/resource_kustomization.go
+++ b/kustomize/resource_kustomization.go
@@ -439,6 +439,7 @@ func kustomizationResourceImport(d *schema.ResourceData, m interface{}) ([]*sche
 	}
 
 	d.Set("manifest", lac)
+	d.Set("wait", d.Get("wait"))
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/kustomize/resource_kustomization_test.go
+++ b/kustomize/resource_kustomization_test.go
@@ -474,6 +474,131 @@ resource "kustomization_resource" "scprov" {
 `
 }
 
+func TestAccResourceKustomization_wait(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		//PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			//
+			//
+			// Applying initial config with a svc and deployment in a namespace with wait
+			{
+				Config: testAccResourceKustomizationConfig_wait("test_kustomizations/wait/initial"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckManifestNestedString("kustomization_resource.dep1", "test", "spec", "selector", "matchLabels", "app"),
+					testAccCheckDeploymentReady("kustomization_resource.dep1", "test-wait", "test"),
+				),
+			},
+			//
+			//
+			// Applying modified config updating the deployment annotation with wait
+			{
+				Config: testAccResourceKustomizationConfig_wait("test_kustomizations/wait/modified"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckManifestNestedString("kustomization_resource.dep1", "this will cause a redeploy", "spec", "template", "metadata", "annotations", "new"),
+					testAccCheckDeploymentReady("kustomization_resource.dep1", "test-wait", "test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceKustomizationConfig_wait(path string) string {
+	return testAccDataSourceKustomizationConfig_basic(path) + `
+resource "kustomization_resource" "ns" {
+	manifest = data.kustomization_build.test.manifests["_/Namespace/_/test-wait"]
+}
+resource "kustomization_resource" "dep1" {
+	manifest = data.kustomization_build.test.manifests["apps/Deployment/test-wait/test"]
+	wait     = true
+	timeouts {
+		create = "1m"
+		update = "1m"
+	}
+}
+`
+}
+
+func TestAccResourceKustomization_wait_failure(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		//PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			//
+			//
+			// Applying initial config with a svc and a failing deployment in a namespace with wait
+			{
+				Config: testAccResourceKustomizationConfig_wait_failure("test_kustomizations/wait-fail/initial"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDeploymentNotReady("kustomization_resource.dep1", "test-wait-fail", "test"),
+				),
+				ExpectError: regexp.MustCompile("timed out creating/updating Deployment test-wait-fail/test:"),
+			},
+		},
+	})
+}
+
+func testAccResourceKustomizationConfig_wait_failure(path string) string {
+	return testAccDataSourceKustomizationConfig_basic(path) + `
+resource "kustomization_resource" "ns" {
+	manifest = data.kustomization_build.test.manifests["_/Namespace/_/test-wait-fail"]
+}
+resource "kustomization_resource" "dep1" {
+	manifest = data.kustomization_build.test.manifests["apps/Deployment/test-wait-fail/test"]
+	wait     = true
+	timeouts {
+		create = "1m"
+	}
+}
+`
+}
+
+func TestAccResourceKustomization_nowait(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		//PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			//
+			//
+			// Applying initial config with a svc and deployment in a namespace without wait
+			// so shouldn't exist immediately after creation
+			{
+				Config: testAccResourceKustomizationConfig_nowait("test_kustomizations/nowait/initial"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckManifestNestedString("kustomization_resource.dep1", "test", "spec", "selector", "matchLabels", "app"),
+					testAccCheckDeploymentNotReady("kustomization_resource.dep1", "test-nowait", "test"),
+				),
+			},
+			//
+			//
+			// Applying modified config updating the deployment annotation without wait,
+			// so we don't immediately expect the annotation to be present
+			{
+				Config: testAccResourceKustomizationConfig_nowait("test_kustomizations/nowait/modified"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckManifestNestedString("kustomization_resource.dep1", "this will cause a redeploy", "spec", "template", "metadata", "annotations", "new"),
+					testAccCheckDeploymentNotReady("kustomization_resource.dep1", "test-nowait", "test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceKustomizationConfig_nowait(path string) string {
+	return testAccDataSourceKustomizationConfig_basic(path) + `
+resource "kustomization_resource" "ns" {
+	manifest = data.kustomization_build.test.manifests["_/Namespace/_/test-nowait"]
+}
+
+resource "kustomization_resource" "dep1" {
+	manifest = data.kustomization_build.test.manifests["apps/Deployment/test-nowait/test"]
+}
+`
+}
+
 // Upgrade_API_Version Test
 func TestAccResourceKustomization_upgradeAPIVersion(t *testing.T) {
 
@@ -886,6 +1011,50 @@ func testAccCheckDeploymentPurged(n string) resource.TestCheckFunc {
 			return fmt.Errorf("Resource not purged from K8s api: %s", n)
 		}
 
+		return nil
+	}
+}
+
+func testAccCheckDeploymentReady(n string, namespace string, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		u, err := getResourceFromTestState(s, n)
+		if err != nil {
+			return err
+		}
+
+		resp, err := getResourceFromK8sAPI(u)
+		if err != nil {
+			return err
+		}
+		ready, err := deploymentReady(resp)
+		if err != nil {
+			return err
+		}
+		if !ready {
+			return fmt.Errorf("deployment %s in %s not ready", name, namespace)
+		}
+		return nil
+	}
+}
+
+func testAccCheckDeploymentNotReady(n string, namespace string, name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		u, err := getResourceFromTestState(s, n)
+		if err != nil {
+			return err
+		}
+
+		resp, err := getResourceFromK8sAPI(u)
+		if err != nil {
+			return err
+		}
+		ready, err := deploymentReady(resp)
+		if err != nil {
+			return err
+		}
+		if ready {
+			return fmt.Errorf("deployment %s in %s unexpectedly ready", name, namespace)
+		}
 		return nil
 	}
 }

--- a/kustomize/test_kustomizations/nowait/initial/kustomization.yaml
+++ b/kustomize/test_kustomizations/nowait/initial/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: test-nowait
+
+resources:
+- namespace.yaml
+- ../../_example_app

--- a/kustomize/test_kustomizations/nowait/initial/namespace.yaml
+++ b/kustomize/test_kustomizations/nowait/initial/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-nowait

--- a/kustomize/test_kustomizations/nowait/modified/kustomization.yaml
+++ b/kustomize/test_kustomizations/nowait/modified/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../initial
+
+patches:
+  - target: 
+      kind: Deployment
+      name: test
+    patch: |
+      - op: add
+        path: /spec/template/metadata/annotations
+        value: 
+          new: this will cause a redeploy

--- a/kustomize/test_kustomizations/wait-fail/initial/kustomization.yaml
+++ b/kustomize/test_kustomizations/wait-fail/initial/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: test-wait-fail
+
+resources:
+- namespace.yaml
+- ../../_example_app
+
+images:
+  - name: nginx
+    newName: doesnotexist/definitelydoesntexist

--- a/kustomize/test_kustomizations/wait-fail/initial/namespace.yaml
+++ b/kustomize/test_kustomizations/wait-fail/initial/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-wait-fail

--- a/kustomize/test_kustomizations/wait/initial/kustomization.yaml
+++ b/kustomize/test_kustomizations/wait/initial/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: test-wait
+
+resources:
+- namespace.yaml
+- ../../_example_app

--- a/kustomize/test_kustomizations/wait/initial/namespace.yaml
+++ b/kustomize/test_kustomizations/wait/initial/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-wait

--- a/kustomize/test_kustomizations/wait/modified/kustomization.yaml
+++ b/kustomize/test_kustomizations/wait/modified/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../initial
+
+patches:
+  - target: 
+      kind: Deployment
+      name: test
+    patch: |
+      - op: add
+        path: /spec/template/metadata/annotations
+        value: 
+          new: this will cause a redeploy


### PR DESCRIPTION
Allow terraform to correctly report whether a deployment or daemonset has timed out becoming ready (where ready means that all pods are up to date relative to the spec)