### PR TITLE
support remaining Kustomize flags

### DIFF
--- a/kustomize/data_source_kustomization_build.go
+++ b/kustomize/data_source_kustomization_build.go
@@ -27,7 +27,19 @@ func dataSourceKustomization() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"enable_alpha_plugins": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"enable_exec": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
 						"enable_helm": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"enable_star": {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},

--- a/kustomize/data_source_kustomization_overlay.go
+++ b/kustomize/data_source_kustomization_overlay.go
@@ -643,7 +643,19 @@ func dataSourceKustomizationOverlay() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"enable_alpha_plugins": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"enable_exec": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
 						"enable_helm": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"enable_star": {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},


### PR DESCRIPTION
Basically I need to run a custom KRM `exec` to fix the deployment and need some of those flags to make it work, at the same time I've added rest of the flags.


- [x] checked working with `dev_overrides`
- [x] releasing as https://registry.terraform.io/providers/nazarewk-iac/kustomization (still building)
- [ ] docs update