### PR TITLE
adding support for provider parameters host, cluster_ca_certificate, token

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,10 @@ provider "kustomization" {
   # kubeconfig_raw = data.template_file.kubeconfig.rendered
   # kubeconfig_raw = yamlencode(local.kubeconfig)
 
+  # host = "https://${module.testing_gke_core.endpoint}"
+  # token = data.google_client_config.default.access_token
+  # cluster_ca_certificate = base64decode(module.testing_gke_core.ca_certificate)
+
   # kubeconfig_incluster = true
 }
 
@@ -44,6 +48,9 @@ provider "kustomization" {
 
 - `kubeconfig_path` - Path to a kubeconfig file. Can be set using `KUBECONFIG_PATH` environment variable.
 - `kubeconfig_raw` - Raw kubeconfig file. If `kubeconfig_raw` is set, `kubeconfig_path` is ignored.
+- `host` - The hostname (in form of URI) of Kubernetes master.
+- `cluster_ca_certificate` - PEM-encoded root certificates bundle for TLS authentication.
+- `token` - Token to authentifcate an service account
 - `kubeconfig_incluster` - Set to `true` when running inside a kubernetes cluster.
 - `context` - (Optional) Context to use in kubeconfig with multiple contexts, if not specified the default context is used.
 - `legacy_id_format` - (Optional) Defaults to `false`. Provided for backward compability, set to `true` to use the legacy ID format. Removed starting `0.9.0`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ provider "kustomization" {
 
 - `kubeconfig_path` - Path to a kubeconfig file. Can be set using `KUBECONFIG_PATH` environment variable.
 - `kubeconfig_raw` - Raw kubeconfig file. If `kubeconfig_raw` is set, `kubeconfig_path` is ignored.
-- `host` - The hostname (in form of URI) of Kubernetes master.
+- `host` - The hostname (in form of URI) of Kubernetes master, if `kubeconfig_incluster` is set, this parameter along with `cluster_ca_certificate` and `token` are ignored.
 - `cluster_ca_certificate` - PEM-encoded root certificates bundle for TLS authentication.
 - `token` - Token to authentifcate an service account
 - `kubeconfig_incluster` - Set to `true` when running inside a kubernetes cluster.

--- a/kustomize/provider.go
+++ b/kustomize/provider.go
@@ -76,7 +76,7 @@ func Provider() *schema.Provider {
 				Optional:     true,
 				ExactlyOneOf: []string{"kubeconfig_path", "kubeconfig_raw", "kubeconfig_incluster", "host"},
 				RequiredWith: []string{"host", "cluster_ca_certificate", "token"},
-				Description:  "The hostname (in form of URI) of Kubernetes master.",
+				Description:  "The hostname (in form of URI) of Kubernetes master, if kubeconfig_incluster is set, this parameter along with cluster_ca_certificate and token are ignored.",
 			},
 			"cluster_ca_certificate": {
 				Type:         schema.TypeString,


### PR DESCRIPTION
resolving #96 #109 and #143 

added the params and tested it.

So now we can do
```
provider "kustomization" {
  host                   = "https://${module.testing_gke_core.endpoint}"
  token                  = data.google_client_config.default.access_token
  cluster_ca_certificate = base64decode(module.testing_gke_core.ca_certificate)
}
```

Note this is my first time writing something in go and I just copied pasted things until it worked, let me know if there is any issue.