### PR TITLE
Add missing " in overlay.md

### DIFF
--- a/docs/data-sources/overlay.md
+++ b/docs/data-sources/overlay.md
@@ -442,7 +442,7 @@ data "kustomization_overlay" "example" {
     target {
       select {
         name = "hello"
-        kind = "Job
+        kind = "Job"
       }
       field_paths = [
         "spec.template.spec.containers.[name=hello].env.[name=SECRET_TOKEN].value"


### PR DESCRIPTION
It messes up syntax highlighting, and is not pretty.