### PR TITLE
Add api_versions and kube_version to helm_charts block

### DIFF
--- a/docs/data-sources/overlay.md
+++ b/docs/data-sources/overlay.md
@@ -630,6 +630,8 @@ Must enable helm support via [kustomize_options](#kustomize_options---optional) 
 - `values_file` specify a file with helm values to use for templating. Not specifying this uses the in-chart values file, if one exists.
 - `values_inline` specify helm values inline from terraform, as a string
 - `values_merge` merge strategy if both `values_file` and `values_inline` are specified. Can be one of `override`, `replace`, `merge`. (default: `override`)
+- `api_versions` List of Kubernetes api versions used for Capabilities.APIVersions.
+- `kube_version` Allows specifying a custom kubernetes version to use when templating.
 
 #### Example
 
@@ -642,6 +644,8 @@ data "kustomization_overlay" "minecraft" {
     release_name = "moria"
     include_crds = false
     skip_tests = false
+    kube_version = "1.29.0"
+    api_versions = ["monitoring.coreos.com/v1"]
     values_inline = <<VALUES
       minecraftServer:
         eula: true

--- a/kustomize/data_source_kustomization_overlay.go
+++ b/kustomize/data_source_kustomization_overlay.go
@@ -505,6 +505,15 @@ func dataSourceKustomizationOverlay() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"api_versions": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"kube_version": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -1010,6 +1019,8 @@ func getKustomization(d *schema.ResourceData) (k types.Kustomization) {
 			hca.ValuesMerge = hc["values_merge"].(string)
 			hca.IncludeCRDs = hc["include_crds"].(bool)
 			hca.SkipTests = hc["skip_tests"].(bool)
+			hca.KubeVersion = hc["kube_version"].(string)
+			hca.ApiVersions = convertListInterfaceToListString(hc["api_versions"].([]interface{}))
 
 			hc_vi := make(map[string]interface{})
 			if err := yaml.Unmarshal([]byte(hc["values_inline"].(string)), &hc_vi); err != nil {

--- a/kustomize/test_kustomizations/helm/initial/charts/test-capabilities/Chart.yaml
+++ b/kustomize/test_kustomizations/helm/initial/charts/test-capabilities/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+description: A Simple Helm chart to test capabilitie set by the user
+name: test-capabilities
+version: 0.0.1

--- a/kustomize/test_kustomizations/helm/initial/charts/test-capabilities/templates/_helpers.tpl
+++ b/kustomize/test_kustomizations/helm/initial/charts/test-capabilities/templates/_helpers.tpl
@@ -1,0 +1,6 @@
+{{/*
+Expand the name of the chart. Set the chart name to nginx by default
+*/}}
+{{- define "test-capabilities.name" -}}
+{{- .Release.Name | default "capabilities" }}
+{{- end }}

--- a/kustomize/test_kustomizations/helm/initial/charts/test-capabilities/templates/configmap.yaml
+++ b/kustomize/test_kustomizations/helm/initial/charts/test-capabilities/templates/configmap.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: default-configmap
+  labels:
+    app: {{ include "test-capabilities.name" . }}
+    name: {{ include "test-capabilities.name" . }}
+data:
+  should: "always exist" 
+---
+{{ if eq .Capabilities.KubeVersion.Version "v1.42.0" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubeversion-configmap
+  labels:
+    app: {{ include "test-capabilities.name" . }}
+    name: {{ include "test-capabilities.name" . }}
+data:
+  should: "only when kubeversion is equals v1.42.0"
+{{- end }}
+---
+{{ if $.Capabilities.APIVersions.Has "foo.bar/v1" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: apiversions-configmap
+  labels:
+    app: {{ include "test-capabilities.name" . }}
+    name: {{ include "test-capabilities.name" . }}
+data:
+  should: "only when a the fake apiVersion is set"
+{{- end }}


### PR DESCRIPTION
There are some field mappings missing the `helm_charts` block.
This MR adds the `api_versions` list and the `kube_version` field in order to provide this fields to an Helm chart using the `$.Capabilities.APIVersions.Has` checks. 

Refference:
* https://github.com/kubernetes-sigs/kustomize/blob/api/v0.17.1/api/types/helmchartargs.go#L37
* https://github.com/grafana/loki/blob/main/production/helm/loki/templates/monitoring/servicemonitor.yaml#L2C13-L2C43