### PR TITLE
Fix warnings for tests and build process

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          runner: ["ubuntu-latest", "windows-latest", "macos-latest"]
+          runner: ["ubuntu-24.04", "windows-latest", "macos-latest"]
 
     steps:
     - name: Checkout using linefeed for tests
@@ -54,7 +54,7 @@ jobs:
         go test -ldflags "-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=ignore" -v ./kustomize
 
   compile_provider:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - name: 'Checkout'
@@ -91,7 +91,7 @@ jobs:
         path: dist/terraform.d/plugins
 
   int_test_kubeconfig_path:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [compile_provider]
 
     env:
@@ -129,7 +129,7 @@ jobs:
       run: terraform apply --auto-approve
 
   int_test_kubeconfig_raw:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [compile_provider]
 
     steps:
@@ -172,7 +172,7 @@ jobs:
       run: terraform apply --auto-approve
 
   int_test_in_cluster:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [compile_provider]
 
     steps:
@@ -222,7 +222,7 @@ jobs:
       run: kubectl exec -it terraform -- terraform apply --auto-approve
 
   int_test_state_import:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [compile_provider]
 
     env:
@@ -277,7 +277,7 @@ jobs:
       run: terraform apply --auto-approve
   
   int_test_state_migration:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [compile_provider]
 
     env:
@@ -329,7 +329,7 @@ jobs:
       run: terraform apply --auto-approve
 
   int_test_kubestack_kind:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [compile_provider]
 
     steps:
@@ -396,7 +396,7 @@ jobs:
           terraform destroy --auto-approve
 
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - tf_tests
       - int_test_kubeconfig_path

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          runner: ["ubuntu-24.04", "windows-latest", "macos-latest"]
+          runner: ["ubuntu-latest", "windows-latest", "macos-latest"]
 
     steps:
     - name: Checkout using linefeed for tests
@@ -54,7 +54,7 @@ jobs:
         go test -ldflags "-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=ignore" -v ./kustomize
 
   compile_provider:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: 'Checkout'
@@ -91,7 +91,7 @@ jobs:
         path: dist/terraform.d/plugins
 
   int_test_kubeconfig_path:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: [compile_provider]
 
     env:
@@ -129,7 +129,7 @@ jobs:
       run: terraform apply --auto-approve
 
   int_test_kubeconfig_raw:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: [compile_provider]
 
     steps:
@@ -172,7 +172,7 @@ jobs:
       run: terraform apply --auto-approve
 
   int_test_in_cluster:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: [compile_provider]
 
     steps:
@@ -222,7 +222,7 @@ jobs:
       run: kubectl exec -it terraform -- terraform apply --auto-approve
 
   int_test_state_import:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: [compile_provider]
 
     env:
@@ -277,7 +277,7 @@ jobs:
       run: terraform apply --auto-approve
   
   int_test_state_migration:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: [compile_provider]
 
     env:
@@ -329,7 +329,7 @@ jobs:
       run: terraform apply --auto-approve
 
   int_test_kubestack_kind:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: [compile_provider]
 
     steps:
@@ -396,7 +396,7 @@ jobs:
           terraform destroy --auto-approve
 
   goreleaser:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs:
       - tf_tests
       - int_test_kubeconfig_path

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,7 @@ jobs:
         cp ./dist/terraform-provider-kustomization_linux_amd64_v1/terraform-provider-kustomization_v* ./dist/terraform.d/plugins/registry.terraform.io/kbst/kustomization/1.0.0/linux_amd64/terraform-provider-kustomization_v1.0.0
 
     - name: 'Upload terraform-plugins'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: terraform-plugins
         path: dist/terraform.d/plugins
@@ -108,7 +108,7 @@ jobs:
         terraform_version: "${{ env.TERRAFORM_VERSION }}"
 
     - name: 'Download terraform-plugins'
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: terraform-plugins
         path: terraform.d/plugins
@@ -149,7 +149,7 @@ jobs:
         terraform_version: "${{ env.TERRAFORM_VERSION }}"
 
     - name: 'Download terraform-plugins'
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: terraform-plugins
         path: terraform.d/plugins
@@ -186,7 +186,7 @@ jobs:
         cluster_name: ci
 
     - name: 'Download terraform-plugins'
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: terraform-plugins
         path: terraform.d/plugins
@@ -245,7 +245,7 @@ jobs:
         terraform_version: "${{ env.TERRAFORM_VERSION }}"
 
     - name: 'Download terraform-plugins'
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: terraform-plugins
         path: terraform.d/plugins
@@ -310,7 +310,7 @@ jobs:
       run: terraform apply --auto-approve
 
     - name: 'Download terraform-plugins'
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: terraform-plugins
         path: terraform.d/plugins
@@ -337,7 +337,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: 'Download terraform-plugins'
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: terraform-plugins
         path: tests/kubestack-starter-kind/terraform.d/plugins

--- a/kustomize/data_source_kustomization_overlay_test.go
+++ b/kustomize/data_source_kustomization_overlay_test.go
@@ -133,6 +133,11 @@ output "check" {
 
 // Test common_labels attr
 func TestDataSourceKustomizationOverlay_commonLabels(t *testing.T) {
+	// Unfortunately, the controversial commonLabels deprecation
+	// https://github.com/kubernetes-sigs/kustomize/issues/5436#issuecomment-2442056536
+	// produces those annoying deprecation warnings. Keep the test until Kustomize
+	// provides a well-documented alternative that everybody can switch to.
+	// Then, after some time, we can delete the test for commonLabels.
 
 	resource.Test(t, resource.TestCase{
 		IsUnitTest: true,

--- a/kustomize/test_kustomizations/fail_plan_invalid/invalid_cluster_role_binding.yaml
+++ b/kustomize/test_kustomizations/fail_plan_invalid/invalid_cluster_role_binding.yaml
@@ -7,8 +7,7 @@ subjects:
   name: admins
   apiGroup: rbac.authorization.k8s.io
 roleRef:
-  # invalid roleRef to fail test
+  # invalid roleRef to fail test - roleRef should reference a ClusterRole, not a Role
   kind: Role
   name: secret-reader
-  namespace: default
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
* Keep the test semantic for TestAccResourceKustomization_failPlanInvalid but remove warning
* Warnings on ubuntu-latest to change semantics on github: before they switch semantics and (possible) break the builds, switch explicitly to ubuntu 24.04
* Fix upload-artifact deprecation, which would break the build in January 2025
* Add note on commonLabels deprecation, keep the tests