### PR TITLE
Fix goreleaser - adjust config to version 2

### DIFF
--- a/.goreleaser-build.yml
+++ b/.goreleaser-build.yml
@@ -1,3 +1,4 @@
+version: 2
 before:
   hooks:
     - go mod tidy

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 before:
   hooks:
     - go mod tidy
@@ -49,4 +50,4 @@ release:
   draft: true
   prerelease: auto
 changelog:
-  skip: false
+  disable: false


### PR DESCRIPTION
Tested locally both `.goreleaser-build.yml` and `.goreleaser.yml`, except GPG signing
