### PR TITLE
Add Support for Exec-based Credential Plugin in Kustomization Provider

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -48,6 +48,11 @@ provider "kustomization" {
 - `context` - (Optional) Context to use in kubeconfig with multiple contexts, if not specified the default context is used.
 - `legacy_id_format` - (Optional) Defaults to `false`. Provided for backward compability, set to `true` to use the legacy ID format. Removed starting `0.9.0`.
 - `gzip_last_applied_config` - (Optional) Defaults to `true`. Use a gzip compressed and base64 encoded value for the lastAppliedConfig annotation if a resource would otherwise exceed the Kubernetes max annotation size. All other resources use the regular uncompressed annotation. Set to `false` to never use the compressed annotation.
+- `exec` - (Optional) Configuration block to use an [exec-based credential plugin] (https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins), e.g. call an external command to receive user credentials.
+    - `api_version` - (Required) API version to use when decoding the ExecCredentials resource, e.g. `client.authentication.k8s.io/v1beta1`.
+    - `command` - (Required) Command to execute.
+    - `args` - (Optional) List of arguments to pass when executing the plugin.
+    - `env` - (Optional) Map of environment variables to set when executing the plugin.
 
 ## Migrating resource IDs from legacy format to format enabling API version upgrades
 

--- a/kustomize/structures.go
+++ b/kustomize/structures.go
@@ -1,0 +1,14 @@
+package kustomize
+
+func expandStringSlice(s []interface{}) []string {
+	result := make([]string, len(s), len(s))
+	for k, v := range s {
+		// Handle the Terraform parser bug which turns empty strings in lists to nil.
+		if v == nil {
+			result[k] = ""
+		} else {
+			result[k] = v.(string)
+		}
+	}
+	return result
+}

--- a/kustomize/structures_test.go
+++ b/kustomize/structures_test.go
@@ -1,0 +1,40 @@
+package kustomize
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_expandStringSlice(t *testing.T) {
+	type args struct {
+		s []interface{}
+	}
+	tests := []struct {
+		name  string
+		given []interface{}
+		then  []string
+	}{
+		{
+			"validate non empty strings not mutated",
+			[]interface{}{"one", "two"},
+			[]string{"one", "two"},
+		},
+		{
+			"validate nil elements are empty strings",
+			[]interface{}{nil, "two"},
+			[]string{"", "two"},
+		},
+		{
+			"validate empty array",
+			[]interface{}{},
+			[]string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := expandStringSlice(tt.given); !reflect.DeepEqual(got, tt.then) {
+				t.Errorf("expandStringSlice() = %v, want %v", got, tt.then)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request introduces support for an exec-based credential plugin in the Kustomization Terraform provider, enhancing its authentication capabilities. The key changes include:

1. **Provider Code Enhancement:**  
   The `kustomize/provider.go` file has been modified to incorporate the exec-based credential configuration. The provider now includes a new configuration block, `exec`, which supports executing an external command for credential retrieval. The required and optional parameters are handled within the provider's schema.

2. **Supporting Functionality:**  
   A new function, `expandStringSlice`, has been added to `kustomize/structures.go` to assist in processing command arguments. This function addresses a Terraform parser issue by converting nil elements in argument lists to empty strings.

3. **Unit Testing:**  
   Corresponding unit tests for `expandStringSlice` have been added in `kustomize/structures_test.go`. These tests ensure that the function correctly handles non-empty strings, nil elements, and empty arrays.

4. **Documentation Update:**  
   The documentation has been updated to include the new `exec` configuration block. This block allows users to specify an external command that can be executed to retrieve user credentials using the exec-based credential plugin. Parameters such as `api_version`, `command`, `args`, and `env` are detailed to guide users in configuring this feature.

These enhancements provide users with a more flexible authentication mechanism, allowing integration with custom credential providers. This update aligns the provider with modern Kubernetes practices, offering a robust solution for dynamic and secure credential management.